### PR TITLE
Fixed json conversion bug

### DIFF
--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -38,6 +38,11 @@ class StatMap(models.Model):
         unique_together = ("study", "name")
 
     def save(self):
+
+        # Save the file before the rest of the data so we can convert it to json
+        if self.file and not os.path.exists(self.file.path):
+            self.file.save(self.file.name, self.file, save = False)
+        # Convert binary image to JSON using neurosynth
         try:
             if os.path.exists(self.file.path):
                 json_file = self.file.path + '.json'


### PR DESCRIPTION
Fixed the issue with images not being converted to JSON when a statmap file is first uploaded. I'm overriding the save method, so the JSON conversion code was being called before the uploaded file had been saved to disk. I now save the file first, then convert to JSON, then call super to finish saving the rest of the object.

Chris, once you patch your app, try running it again and see if you get the functional overlays to show up properly. (Keep in mind you have to have the neurosynth package installed, otherwise no JSON file will be created. The created files go in /data/statmaps, so if you don't see anything there, something's failing.)
