### PR TITLE
FEAT directory support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ neurovault/local_settings.py
 neurovault/secrets.py
 neurovault/static/
 
+# test data
+neurovault/apps/statmaps/tests/test_data/feat/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html.haml
@@ -118,6 +118,17 @@
                             <em>Private Collection</em>: To share the link to this collection, please use the private url:
                                     %a{href: "{{ request.path }}" }
                                         {{ request.path }}
+
+        {% if messages %}
+        %ul.messages
+        {% for message in messages %}
+            .alert.fade.in{class:"{{ message.tags }}"}
+                %button.close{"data-dismiss" => "alert", :type => "button"} ×
+                {{ message }}
+        {% endfor %}
+        {% endif %}
+
+
         %ul#collection-tabs.nav.nav-tabs
             %li
                 %a{href:'#images', data-toggle:'tab'} Images

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html.haml
@@ -53,10 +53,11 @@
                 	data = new FormData()
 
                 	for i of files
-                		if files[i].name != undefined
-                			if files[i].name.indexOf(".") != 0 && files[i].webkitRelativePath != undefined
+                		if files[i].name != undefined && files[i].webkitRelativePath != undefined
+                			if files[i].name.indexOf(".") != 0  && files[i].webkitRelativePath.indexOf('.files') == -1
                 				data.append('paths[]', files[i].webkitRelativePath)
                 				data.append('file_input[]', files[i])
+
                 	csrftoken = $.cookie('csrftoken')
                 	xhr.open 'POST', "upload_folder", false
                 	xhr.setRequestHeader "X-CSRFToken", csrftoken

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html.haml
@@ -51,14 +51,12 @@
                 	files = e.target.files
                 	xhr = new XMLHttpRequest()
                 	data = new FormData()
-                	for i of files
-                		if files[i].name != "." && files[i].webkitRelativePath != undefined
-                			data.append('paths[]', files[i].webkitRelativePath)
-                	for i of files
-                		if files[i].name != "." && files[i].webkitRelativePath != undefined
-                			data.append('file_input[]', files[i])
 
-
+                	for i of files
+                		if files[i].name != undefined
+                			if files[i].name.indexOf(".") != 0 && files[i].webkitRelativePath != undefined
+                				data.append('paths[]', files[i].webkitRelativePath)
+                				data.append('file_input[]', files[i])
                 	csrftoken = $.cookie('csrftoken')
                 	xhr.open 'POST', "upload_folder", false
                 	xhr.setRequestHeader "X-CSRFToken", csrftoken

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html.haml
@@ -4,6 +4,7 @@
 
     :javascript
         {% inlinecoffeescript %}
+            uldata = undefined
             $(document).ready ->
 
                 $('#show-viewer').click( () =>
@@ -35,35 +36,42 @@
                 )
 
                 $('#upload_archive').click((e) ->
-                	document.getElementById("{{form.file.auto_id}}").click()
+                    document.getElementById("{{form.file.auto_id}}").click()
                 )
 
                 $('#upload_folder').click((e) ->
-                	document.getElementById("folder_input").click()
+                    document.getElementById("folder_input").click()
                 )
 
                 $('#{{form.file.auto_id}}').change((e) ->
-                	document.upload_folder_form.submit();
+                    document.upload_folder_form.submit();
                 )
 
                 $('#folder_input').change((e) ->
-                	paths = ""
-                	files = e.target.files
-                	xhr = new XMLHttpRequest()
-                	data = new FormData()
-
-                	for i of files
-                		if files[i].name != undefined && files[i].webkitRelativePath != undefined
-                			if files[i].name.indexOf(".") != 0  && files[i].webkitRelativePath.indexOf('.files') == -1
-                				data.append('paths[]', files[i].webkitRelativePath)
-                				data.append('file_input[]', files[i])
-
-                	csrftoken = $.cookie('csrftoken')
-                	xhr.open 'POST', "upload_folder", false
-                	xhr.setRequestHeader "X-CSRFToken", csrftoken
-                	xhr.send(data)
-                	document.location = ""
+                    uldata = e.target.files
+                    $('#upload_process').modal 'show'
                 )
+
+                $("#upload_process").on "shown", (e) ->
+
+                    paths = ""
+                    files = uldata
+                    xhr = new XMLHttpRequest()
+                    data = new FormData()
+
+                    for i of files
+                        if files[i].name != undefined && files[i].webkitRelativePath != undefined
+                            if files[i].name.indexOf(".") != 0  && files[i].webkitRelativePath.indexOf('.files') == -1
+                                data.append('paths[]', files[i].webkitRelativePath)
+                                data.append('file_input[]', files[i])
+
+                    csrftoken = $.cookie('csrftoken')
+                    xhr.open 'POST', "upload_folder", false
+                    xhr.setRequestHeader "X-CSRFToken", csrftoken
+                    xhr.send(data)
+                    $('#upload_process').modal 'hide'
+                    document.location = ""
+
 
                 if navigator.userAgent.indexOf("Safari") > -1 and navigator.userAgent.indexOf("Chrome") == -1
                     $('a[href="pycortex"]').hide()
@@ -79,8 +87,8 @@
         - if collection.authors
             .lead {{collection.authors}}
         - if collection.DOI
-        	.lead
-        		%a{href:"{{ collection.url }}" } Link to the paper
+            .lead
+                %a{href:"{{ collection.url }}" } Link to the paper
 
 
         .management-options
@@ -161,6 +169,13 @@
                     %tbody
             #viewer.tab-pane
                 {% include 'statmaps/_neurosynth_viewer_content.html.haml' %}
+
+            #upload_process.modal.fade.hide{data-backdrop: 'static', data-keyboard:'false', style: 'margin-top: 175px;'}
+                .modal-header
+                    %h4 Processing upload...
+                .modal-body
+                    .progress.progress-striped.active
+                        .bar{"style":"width: 100%;"}
 
 {% comment %}
 {% for image in collection.image_set.all %}

--- a/neurovault/apps/statmaps/tests/test_data/feat/readme.txt
+++ b/neurovault/apps/statmaps/tests/test_data/feat/readme.txt
@@ -1,0 +1,1 @@
+FEAT test data can be found in the data repository: https://github.com/NeuroVault/neurovault_data/tree/master/FEAT_testdata

--- a/neurovault/apps/statmaps/tests/test_feat.py
+++ b/neurovault/apps/statmaps/tests/test_feat.py
@@ -1,0 +1,137 @@
+from django.test import TestCase, Client
+from neurovault.apps.statmaps.models import Collection,User
+import tempfile
+import os
+import shutil
+from django.core.files.uploadedfile import SimpleUploadedFile
+from neurovault.apps.statmaps.forms import NIDMResultsForm
+from neurovault.apps.statmaps.utils import detect_feat_directory, get_traceback
+from nidmfsl.fsl_exporter.fsl_exporter import FSLtoNIDMExporter
+import urllib
+import zipfile
+
+
+class FeatDirectoryTest(TestCase):
+
+    def setUp(self):
+        testpath = os.path.join(os.path.abspath(os.path.dirname(__file__)),'test_data','feat')
+        testdata_repo = 'https://github.com/NeuroVault/neurovault_data/blob/master/FEAT_testdata/'
+
+        self.testfiles = {
+            'ds105.feat.zip': {
+                'fileuri':'ds105.feat.zip?raw=true',
+                'num_statmaps':2,
+                'export_dir':'ds105.feat/cope1.feat/nidm',
+                'ttl_fsize': 37872,
+                'map_types': ['T','Z'],
+                'names':['Statistic Map: group mean', 'Z-Statistic Map: group mean'],
+
+            },
+
+            'ds017A.zip': {
+                'fileuri':'ds017A.zip?raw=true',
+                'num_statmaps':2,
+                'export_dir': 'ds017A/group/model001/task001/cope001.gfeat/cope1.feat/nidm',
+                'ttl_fsize': 68026,
+                'map_types': ['T','Z'],
+                'names':['Statistic Map: group mean', 'Z-Statistic Map: group mean'],
+            },
+        }
+
+        self.tmpdir = tempfile.mkdtemp()
+        self.user = User.objects.create_user('NeuroGuy')
+        self.user.save()
+        self.client = Client()
+        self.client.login(username=self.user)
+        self.coll = Collection(owner=self.user, name="Test Collection")
+        self.coll.save()
+
+        # FEAT test data is large so it lives in the external data repo
+        for fname, info in self.testfiles.items():
+            self.testfiles[fname]['file'] = os.path.join(testpath,fname)
+            if not os.path.exists(self.testfiles[fname]['file']):
+                print '\ndownloading test data {}'.format(fname)
+                furl = '{0}{1}'.format(testdata_repo, info['fileuri'])
+                try:
+                    urllib.urlretrieve(furl, self.testfiles[fname]['file'])
+                except:
+                    raise Exception('Unable to download test data {}'.format(fname))
+
+            self.testfiles[fname]['sourcedir'] = self.testfiles[fname]['file'][:-4]
+            self.testfiles[fname]['dir'] = os.path.join(self.tmpdir,fname[:-4])
+
+            if not os.path.exists(self.testfiles[fname]['sourcedir']):
+                try:
+                    fh = open(os.path.join(testpath,fname), 'rb')
+                    z = zipfile.ZipFile(fh)
+                    for name in [v for v in z.namelist() if not v.startswith('.') and
+                                 '/.files' not in v]:
+                        outpath = self.testfiles[fname]['sourcedir']
+                        z.extract(name, outpath)
+                    fh.close()
+                except:
+                    raise Exception('Unable to unzip test data {}'.format(fname))
+
+            shutil.copytree(self.testfiles[fname]['sourcedir'], self.testfiles[fname]['dir'])
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def testFEAT_NIDM(self):
+
+        # test feat parsing
+        for fname, info in self.testfiles.items():
+            info['found_feat'] = False
+            for root, dirs, files in os.walk(info['dir']):
+                if detect_feat_directory(root):
+                    print 'Found FEAT directory at {}.'.format(root)
+                    info['found_feat'] = True
+                    try:
+                        fslnidm = FSLtoNIDMExporter(feat_dir=root, version="0.2.0")
+                        fslnidm.parse()
+                        export_dir = fslnidm.export()
+                        ttl_file = os.path.join(export_dir,'nidm.ttl')
+                    except:
+                        print("Unable to parse the FEAT directory: \n{0}.".format(get_traceback()))
+
+                    # confirm results path and existence
+                    self.assertTrue(os.path.exists(export_dir))
+                    self.assertEquals(os.path.join(info['dir'],info['export_dir']),export_dir)
+
+                    # incomplete ttl = failure in processing
+                    self.assertEquals(os.path.getsize(ttl_file),info['ttl_fsize'])
+
+        # test upload nidm
+        for fname, info in self.testfiles.items():
+
+            nidm_zpath = os.path.join(self.tmpdir,'{}.nidm.zip'.format(fname.replace('.zip','')))
+            nidm_zip = zipfile.ZipFile(nidm_zpath, 'w')
+
+            for root, dirs, files in os.walk(os.path.join(info['dir'],info['export_dir'])):
+                for nfile in files:
+                    nidm_zip.write(os.path.join(root, nfile))
+            nidm_zip.close()
+
+            zname = os.path.basename(nidm_zip.filename)
+            post_dict = {
+                'name': zname,
+                'description':'{0} upload test'.format(zname),
+                'collection':self.coll.pk,
+            }
+
+            file_dict = {'zip_file': SimpleUploadedFile(zname, open(nidm_zpath,'r').read())}
+            form = NIDMResultsForm(post_dict, file_dict)
+
+            # validate NIDM Results
+            self.assertTrue(form.is_valid())
+            nidm = form.save()
+
+            statmaps = nidm.nidmresultstatisticmap_set.all()
+            self.assertEquals(len(statmaps),info['num_statmaps'])
+
+            map_types = [v.map_type for v in statmaps]
+            self.assertEquals(sorted(map_types), sorted(info['map_types']))
+
+            names = [v.name for v in statmaps]
+            self.assertEquals(sorted(names), sorted(info['names']))
+

--- a/neurovault/apps/statmaps/utils.py
+++ b/neurovault/apps/statmaps/utils.py
@@ -368,37 +368,3 @@ def get_server_url(request):
         return request.META['HTTP_ORIGIN']
     urlpref = 'https://' if request.is_secure() else 'http://'
     return '{0}{1}'.format(urlpref,request.META['HTTP_HOST'])
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/neurovault/apps/statmaps/utils.py
+++ b/neurovault/apps/statmaps/utils.py
@@ -289,22 +289,24 @@ def populate_nidm_results(request,collection):
     return form.instance
 
 
-def populate_feat_directory(request,collection):
+def populate_feat_directory(request,collection,existing_dir=None):
     from nidmfsl.fsl_exporter.fsl_exporter import FSLtoNIDMExporter
-    tmp_dir = tempfile.mkdtemp()
+    tmp_dir = tempfile.mkdtemp() if existing_dir is None else existing_dir
     exc = ValidationError
 
     try:
-        zip = zipfile.ZipFile(request.FILES['file'])
-        zip.extractall(path=tmp_dir)
+        if existing_dir is None:
+            zip = zipfile.ZipFile(request.FILES['file'])
+            zip.extractall(path=tmp_dir)
 
-        rootpaths = [v for v in os.listdir(tmp_dir) if not v.startswith('.')]
+        rootpaths = [v for v in os.listdir(tmp_dir)
+                     if not v.startswith('.') and not v.startswith('__MACOSX')]
         if not rootpaths:
-            raise exc("No contents found in the FEAT zip file.")
+            raise exc("No contents found in the FEAT directory.")
         subdir = os.path.join(tmp_dir,rootpaths[0])
-        feat_dir = subdir if len(rootpaths) and os.path.isdir(subdir) else tmp_dir
+        feat_dir = subdir if len(rootpaths) is 1 and os.path.isdir(subdir) else tmp_dir
     except:
-        raise exc("Unable to unzip the FEAT zip file: \n{0}.".format(get_traceback()))
+        raise exc("Unable to unzip the FEAT directory: \n{0}.".format(get_traceback()))
     try:
         fslnidm = FSLtoNIDMExporter(feat_dir=feat_dir, version="0.2.0")
         fslnidm.parse()
@@ -316,7 +318,12 @@ def populate_feat_directory(request,collection):
         raise exc("Unable find nidm export of FEAT directory.")
 
     try:
-        destname = request.FILES['file'].name.replace('feat.zip','feat.nidm.zip')
+        if existing_dir is not None:
+            dname = os.path.basename(feat_dir)
+            suffix = '.nidm.zip' if dname.endswith('feat') else '.feat.nidm.zip'
+            destname = dname + suffix
+        else:
+            destname = request.FILES['file'].name.replace('feat.zip','feat.nidm.zip')
         destpath = os.path.join(tmp_dir,destname)
         nidm_zip = zipfile.ZipFile(destpath, 'w', zipfile.ZIP_DEFLATED)
         rootlen = len(feat_dir) + 1
@@ -331,12 +338,24 @@ def populate_feat_directory(request,collection):
                                     ContentFile(fh.read()), "file", fh.name.split('/')[-1],
                                     "application/zip", os.path.getsize(destpath), "utf-8")
 
-    except Exception:
+    except:
         raise exc("Unable to convert NIDM results for NeuroVault: \n{0}".format(get_traceback()))
     else:
         return populate_nidm_results(request,collection)
     finally:
         shutil.rmtree(tmp_dir)
+
+
+def detect_feat_directory(path):
+    if not os.path.isdir(path):
+        return False
+    # detect FEAT directory, check for for stats/, logs/, logs/feat4_post
+    for root, dirs, files in os.walk(path):
+        if('stats' in dirs and 'logs' in dirs
+           and 'feat4_post' in os.listdir(os.path.join(root,'logs'))):
+            return True
+        else:
+            return False
 
 
 def get_traceback():

--- a/neurovault/apps/statmaps/utils.py
+++ b/neurovault/apps/statmaps/utils.py
@@ -330,7 +330,6 @@ def populate_feat_directory(request,collection,existing_dir=None):
         for root, dirs, files in os.walk(export_dir):
             for dfile in files:
                 filenm = os.path.join(root, dfile)
-                print filenm
                 nidm_zip.write(filenm, filenm[rootlen:])
         nidm_zip.close()
         fh = open(destpath,'r')

--- a/neurovault/apps/statmaps/utils.py
+++ b/neurovault/apps/statmaps/utils.py
@@ -351,7 +351,7 @@ def detect_feat_directory(path):
         return False
     # detect FEAT directory, check for for stats/, logs/, logs/feat4_post
     for root, dirs, files in os.walk(path):
-        if('stats' in dirs and 'logs' in dirs
+        if('stats' in dirs and 'logs' in dirs and 'design.fsf' in files
            and 'feat4_post' in os.listdir(os.path.join(root,'logs'))):
             return True
         else:

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -335,9 +335,6 @@ def upload_folder(request, collection_cid):
                     archive_name = request.FILES['file'].name
                     if fnmatch(archive_name,'*.nidm.zip'):
                         populate_nidm_results(request,collection)
-                    elif fnmatch(archive_name,'*.feat.zip'):
-                        populate_feat_directory(request,collection)
-                        return HttpResponseRedirect(collection.get_absolute_url())
 
                     _, archive_ext = os.path.splitext(archive_name)
                     if archive_ext == '.zip':
@@ -353,10 +350,6 @@ def upload_folder(request, collection_cid):
                         if fnmatch(f.name,'*.nidm.zip'):
                             request.FILES['file'] = f
                             populate_nidm_results(request,collection)
-                            continue
-                        elif fnmatch(f.name,'*.feat.zip'):
-                            request.FILES['file'] = f
-                            populate_feat_directory(request,collection)
                             continue
 
                         new_path, _ = os.path.split(os.path.join(tmp_directory, path))
@@ -460,8 +453,7 @@ def upload_folder(request, collection_cid):
 
             finally:
                 shutil.rmtree(tmp_directory)
-
-            return HttpResponseRedirect('')
+            return HttpResponseRedirect(collection.get_absolute_url())
     else:
         form = UploadFileForm()
     return render_to_response("statmaps/upload_folder.html",

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -369,10 +369,16 @@ def upload_folder(request, collection_cid):
                     raise Exception("Unable to find uploaded files.")
 
                 atlases = {}
-                for root, _, filenames in os.walk(tmp_directory, topdown=False):
+                for root, subdirs, filenames in os.walk(tmp_directory):
                     if detect_feat_directory(root):
                         populate_feat_directory(request,collection,root)
-                        continue
+                        del(subdirs)
+                        filenames = []
+
+                    # .gfeat parent dir under cope*.feat should not be added as statmaps
+                    # this may be affected by future nidm-results_fsl parsing changes
+                    if root.endswith('.gfeat'):
+                        filenames = []
 
                     filenames = [f for f in filenames if not f[0] == '.']
                     for fname in filenames:
@@ -448,6 +454,10 @@ def upload_folder(request, collection_cid):
 
                     new_image.file = f
                     new_image.save()
+            except:
+                #todo: send failure messages as cookie notifications
+                pass
+
             finally:
                 shutil.rmtree(tmp_directory)
 

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -34,6 +34,8 @@ import os
 from collections import OrderedDict
 from xml.dom import minidom
 from django.db.models.aggregates import Count
+from django.contrib import messages
+import traceback
 
 
 def owner_or_contrib(request,collection):
@@ -448,8 +450,10 @@ def upload_folder(request, collection_cid):
                     new_image.file = f
                     new_image.save()
             except:
-                #todo: send failure messages as cookie notifications
-                pass
+                error = traceback.format_exc().splitlines()[-1]
+                msg = "An error occurred with this upload: {}".format(error)
+                messages.warning(request, msg)
+                return
 
             finally:
                 shutil.rmtree(tmp_directory)

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -10,7 +10,7 @@ from django.core.files.base import ContentFile
 from neurovault.apps.statmaps.utils import split_filename, generate_pycortex_volume, \
     generate_pycortex_static, generate_url_token, HttpRedirectException, get_paper_properties, \
     get_file_ctime, detect_afni4D, split_afni4D_to_3D, splitext_nii_gz, mkdir_p, \
-    send_email_notification, populate_nidm_results, get_server_url
+    send_email_notification, populate_nidm_results, get_server_url, populate_feat_directory
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse
 from django.db.models import Q
@@ -334,6 +334,8 @@ def upload_folder(request, collection_cid):
                     archive_name = request.FILES['file'].name
                     if fnmatch(archive_name,'*.nidm.zip'):
                         populate_nidm_results(request,collection)
+                    elif fnmatch(archive_name,'*.feat.zip'):
+                        populate_feat_directory(request,collection)
                         return HttpResponseRedirect(collection.get_absolute_url())
 
                     _, archive_ext = os.path.splitext(archive_name)
@@ -350,6 +352,11 @@ def upload_folder(request, collection_cid):
                             request.FILES['file'] = f
                             populate_nidm_results(request,collection)
                             continue
+                        elif fnmatch(f.name,'*.feat.zip'):
+                            request.FILES['file'] = f
+                            populate_feat_directory(request,collection)
+                            continue
+
                         new_path, _ = os.path.split(os.path.join(tmp_directory, path))
                         mkdir_p(new_path)
                         filename = os.path.join(new_path,f.name)

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -453,7 +453,12 @@ def upload_folder(request, collection_cid):
                 error = traceback.format_exc().splitlines()[-1]
                 msg = "An error occurred with this upload: {}".format(error)
                 messages.warning(request, msg)
-                return
+
+                # redirect error messages for .zip requests
+                if "file" in request.FILES:
+                    return HttpResponseRedirect(collection.get_absolute_url())
+                else:
+                    return
 
             finally:
                 shutil.rmtree(tmp_directory)

--- a/neurovault/settings.py
+++ b/neurovault/settings.py
@@ -268,3 +268,7 @@ os.environ["XDG_CONFIG_HOME"] = PYCORTEX_DATASTORE
 os.environ["FREESURFER_HOME"] = "/opt/freesurfer"
 os.environ["SUBJECTS_DIR"] = os.path.join(os.environ["FREESURFER_HOME"],"subjects")
 os.environ["FSLOUTPUTTYPE"] = "NIFTI_GZ"
+
+# provToolbox path
+os.environ["PATH"] += os.pathsep + '/path/to/lib/provToolbox/bin'
+

--- a/scripts/check_feat_dirs.py
+++ b/scripts/check_feat_dirs.py
@@ -1,5 +1,8 @@
 import os
 import django
+import tempfile
+import shutil
+from subprocess import call
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "neurovault.settings")
 django.setup()
@@ -9,21 +12,32 @@ from neurovault.apps.statmaps.utils import detect_feat_directory, get_traceback
 
 
 if __name__ == '__main__':
-    feat_dirs_path = raw_input("Enter location of test data: ")
+    feat_dirs_path = raw_input("Enter location of test data:") or '/vagrant/FEAT'
     find = 0
     parse = 0
     fail = 0
 
-    for root, _, _ in os.walk(feat_dirs_path, topdown=False):
+    for root, dirs, files in os.walk(feat_dirs_path, topdown=False):
         if detect_feat_directory(root):
+            if '.files' in dirs:
+                call(["rm", "-rf",os.path.join(root,'.files')])
+            tmpdir = tempfile.mkdtemp()
+            feat_dir = os.path.join(tmpdir,os.path.basename(root))
+            shutil.copytree(root, feat_dir)
             print 'found feat directory at {0}'.format(root)
+            print 'testing {0}'.format(feat_dir)
             find += 1
             try:
-                fslnidm = FSLtoNIDMExporter(feat_dir=root, version="0.2.0")
+                fslnidm = FSLtoNIDMExporter(feat_dir=feat_dir, version="0.2.0")
                 fslnidm.parse()
                 export_dir = fslnidm.export()
                 parse += 1
             except:
                 fail += 1
                 print("Unable to parse the FEAT directory: \n{0}.".format(get_traceback()))
+            finally:
+                shutil.rmtree(tmpdir)
+                print 'ttl length: {}'.format(os.path.getsize(os.path.join(export_dir,'nidm.ttl')))
+
     print 'found {0} FEAT dirs, {1} successfully processed, {2} failures.'.format(find,parse,fail)
+

--- a/scripts/check_feat_dirs.py
+++ b/scripts/check_feat_dirs.py
@@ -36,8 +36,8 @@ if __name__ == '__main__':
                 fail += 1
                 print("Unable to parse the FEAT directory: \n{0}.".format(get_traceback()))
             finally:
-                shutil.rmtree(tmpdir)
                 print 'ttl length: {}'.format(os.path.getsize(os.path.join(export_dir,'nidm.ttl')))
+                shutil.rmtree(tmpdir)
 
     print 'found {0} FEAT dirs, {1} successfully processed, {2} failures.'.format(find,parse,fail)
 

--- a/scripts/check_feat_dirs.py
+++ b/scripts/check_feat_dirs.py
@@ -1,0 +1,29 @@
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "neurovault.settings")
+django.setup()
+
+from nidmfsl.fsl_exporter.fsl_exporter import FSLtoNIDMExporter
+from neurovault.apps.statmaps.utils import detect_feat_directory, get_traceback
+
+
+if __name__ == '__main__':
+    feat_dirs_path = raw_input("Enter location of test data: ")
+    find = 0
+    parse = 0
+    fail = 0
+
+    for root, _, _ in os.walk(feat_dirs_path, topdown=False):
+        if detect_feat_directory(root):
+            print 'found feat directory at {0}'.format(root)
+            find += 1
+            try:
+                fslnidm = FSLtoNIDMExporter(feat_dir=root, version="0.2.0")
+                fslnidm.parse()
+                export_dir = fslnidm.export()
+                parse += 1
+            except:
+                fail += 1
+                print("Unable to parse the FEAT directory: \n{0}.".format(get_traceback()))
+    print 'found {0} FEAT dirs, {1} successfully processed, {2} failures.'.format(find,parse,fail)


### PR DESCRIPTION
works well with original example.  importing the converter class seems preferable to calling the executable, and gives us control over the exception handling in our process.

todo:
 - testing
 - etc