### PR TITLE
Enh/image comparison

### DIFF
--- a/neurovault/apps/statmaps/templates/statmaps/compare_search.html
+++ b/neurovault/apps/statmaps/templates/statmaps/compare_search.html
@@ -17,6 +17,20 @@ var addthis_config = {
 
 <script type="text/javascript"> 
 
+var portfolio_filter = document.getElementsByClassName("portfolio-filter")
+var li = document.createElement("li");
+var a = document.createElement("a");
+
+function setAttributes(el, attrs) {
+  for(var key in attrs) {
+    el.setAttribute(key, attrs[key]);
+  }
+}
+
+setAttributes(a, {"class": "btn btn-warning", "disabled": "true"});
+a.appendChild(document.createTextNode(["{{ images_processing }} images still processing"]));
+portfolio_filter[0].appendChild(li.appendChild(a))
+
 $(document).ready(function() {
 
     //$('li.portfolio-item').find('a.btn-danger').click(function(event) {

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -725,6 +725,7 @@ def find_similar(request,pk):
     for comp in comparisons:
         image_ids.append([image_id for image_id in [comp.image1_id,
                          comp.image2_id] if image_id != pk][0])
+    images_processing = len(Image.objects.all()) - len(image_ids)
     scores.insert(0,pk)
     data = pandas.Series(scores,index=image_ids, name=pk)
 
@@ -755,7 +756,7 @@ def find_similar(request,pk):
                                              image_url=image_url,query=query,absolute_value=True,
                                              max_results=100,image_names=image_names)
     html = [h.strip("\n") for h in html_snippet]
-    context = {'html': html}
+    context = {'html': html,'images_processing':images_processing}
     return render(request, 'statmaps/compare_search.html', context)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,5 +36,6 @@ rdflib>=4.1.0
 celery[redis]
 django-celery
 scikit-learn
+python-redis
 -e git://github.com/nilearn/nilearn.git@master#egg=nilearn
 -e git://github.com/vsoch/pybraincompare.git@955182ef6068dc056ab16586ef7c70e65d87301c#egg=pybraincompare

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,6 @@ rdflib>=4.1.0
 celery[redis]
 django-celery
 scikit-learn
-python-redis
+django-redis
 -e git://github.com/nilearn/nilearn.git@master#egg=nilearn
 -e git://github.com/vsoch/pybraincompare.git@955182ef6068dc056ab16586ef7c70e65d87301c#egg=pybraincompare

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,5 @@ rdflib>=4.1.0
 celery[redis]
 django-celery
 scikit-learn
-django-redis
 -e git://github.com/nilearn/nilearn.git@master#egg=nilearn
 -e git://github.com/vsoch/pybraincompare.git@955182ef6068dc056ab16586ef7c70e65d87301c#egg=pybraincompare

--- a/scripts/add_pearson_similarity_metric.py
+++ b/scripts/add_pearson_similarity_metric.py
@@ -9,7 +9,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "neurovault.settings")
 django.setup()
 
 from neurovault.apps.statmaps.models import Similarity, Comparison, Image
-from neurovault.apps.statmaps.tasks import save_voxelwise_pearson_similarity, update_voxelwise_pearson_similarity
+from neurovault.apps.statmaps.tasks import save_voxelwise_pearson_similarity
 from django.db import IntegrityError
 import errno
 


### PR DESCRIPTION
This will add image comparison to NeuroVault, meaning:  a button on image pages that will go to a search interface to show top 100 most similar images, each of  which is linked to the "scatterplot compare" page for the two images.  The query image is in the top right, and image types (Z, beta, Other, etc) are in the top left, so the user can click to filter.  From each image you can also go to the image page.  The glass brains do NOT represent a difference / comparison, but are just the maps themselves, so the user can visually see them vs. the query in the top right.

The images that are included in the comparison come directly from a pkl file that contains a similarity (pearson) correlation matrix, with row and column names corresponding to the image pks.  The button will only show up for an image if it is in this set.  Two things need to happen for this to work:

- the pkl matrix must exist
- the png images (one for each brain map) must also exist

This pull request contains the tasks.py and other celery modules required to get this working, with the tasks written, but they are not integrated anywhere into neurovault for it to happen automatically.  We would need to:

- submit job to celery to generate the brain image glass brain png with generate_glassbrain_image(nifti_file,pk) in statmaps/tasks.py when a new image is added
- (on some timely basis) run "make_correlation_df" (also in statmaps/tasks.py) to generate the public image data frame.  

The png brain glass images go into the image/# folders along with the images, with the format "glass_brain_%s.png" % pk, and the correlation matrix is a pickle that gets saved to  image_data/matrices/pearson_corr.pkl

The guts of the image comparison come from the pybraincompare package, which basically takes in images and stuffs and spits out html, which is then rendered into the neurovault templates.  Here is a list of packages I remember needing to install for my edits (probably these guys go into neurosynth_puppet?):

- [pybraincompare](https://github.com/vsoch/pybraincompare)
- scikit-learn
- nilearn

And another change for puppet would be adding the "matrices" folder under image_data/matrices 

Finally, I'm not sure how the actual deployed image paths looked - if you look under compare_images in views.py I changed the /opt/image_data bits to media and that seemed to work, and I did the same for the compare_search function. 

There are of course much cool things we can add on to this (let the user choose an atlas, more filtering options, show some kind of difference map), but since this is my first contribution I want to start small... baby steps!  I've also never done this before so feel free to be blunt with me in giving instructions! :L) 