### PR TITLE
updated pybraincompare so scatterplot compare gets rid of 4th singleton ...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,4 @@ celery[redis]
 django-celery
 scikit-learn
 -e git://github.com/nilearn/nilearn.git@master#egg=nilearn
--e git://github.com/vsoch/pybraincompare.git@955182ef6068dc056ab16586ef7c70e65d87301c#egg=pybraincompare
+-e git://github.com/vsoch/pybraincompare.git@ca0bd367bd56f07d080e617654ce144a700f2212#egg=pybraincompare


### PR DESCRIPTION
This is just a change to the requirements.txt to link to the updated commit for pybraincompare. The function "do_mask" now eliminates all extra 4th dimensions with np.squeeze.