### PR TITLE
fixes #129 and fixes #130, scatterplot adds pairwise deletion mask, and ...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,4 @@ celery[redis]
 django-celery
 scikit-learn
 -e git://github.com/nilearn/nilearn.git@master#egg=nilearn
--e git://github.com/vsoch/pybraincompare.git@ca0bd367bd56f07d080e617654ce144a700f2212#egg=pybraincompare
+-e git://github.com/vsoch/pybraincompare.git@e14aa83fe726ce4a292e756beccaeaf03c209221#egg=pybraincompare


### PR DESCRIPTION
This works on my local server, but of course will need to be tested on dev. The pybraincompare module has been changed so that all scores, image_ids, image_pngs, query_id, query_png, and image_names are single lists.  There was a but in setting the scores to be the first primary key (scores=[pk]) and the error in labeling was likely because image_names was not added and sorted with the data frame.

The scatterplot compare has been updated to calculate  a pairwise deletion mask, and now regions that are not present in the map should not be rendered on the page.

There are many more things to fix but this is minimally a start! Baby steps! :wink: h