### PR TITLE
find_similar page improvements to fix #148, more spacing, two lines of t...

### DIFF
--- a/neurovault/apps/statmaps/templates/statmaps/compare_search.html
+++ b/neurovault/apps/statmaps/templates/statmaps/compare_search.html
@@ -20,6 +20,7 @@ var addthis_config = {
 var portfolio_filter = document.getElementsByClassName("portfolio-filter")
 var li = document.createElement("li");
 var a = document.createElement("a");
+var image_a = document.createElement("a");
 
 function setAttributes(el, attrs) {
   for(var key in attrs) {
@@ -28,8 +29,13 @@ function setAttributes(el, attrs) {
 }
 
 setAttributes(a, {"class": "btn btn-warning", "disabled": "true"});
+setAttributes(image_a,{"style": "float:right; margin-right:40px; font-weight:800; color:LightSeaGreen;", "href": "{{ image_url }}"});
+
 a.appendChild(document.createTextNode(["{{ images_processing }} images still processing"]));
-portfolio_filter[0].appendChild(li.appendChild(a))
+image_a.appendChild(document.createTextNode(["{{ image_title }}"]));
+li.appendChild(a)
+portfolio_filter[0].appendChild(li.appendChild(image_a));
+
 
 $(document).ready(function() {
 

--- a/neurovault/apps/statmaps/templates/statmaps/compare_search.html
+++ b/neurovault/apps/statmaps/templates/statmaps/compare_search.html
@@ -36,16 +36,6 @@ image_a.appendChild(document.createTextNode(["{{ image_title }}"]));
 li.appendChild(a)
 portfolio_filter[0].appendChild(li.appendChild(image_a));
 
-
-$(document).ready(function() {
-
-    //$('li.portfolio-item').find('a.btn-danger').click(function(event) {
-        //event.preventDefault;
-        //debugger;
-    //    return false;
-    //});
-});
-
 </script>
 
 {% endblock %}

--- a/neurovault/apps/statmaps/templates/statmaps/compare_search.html
+++ b/neurovault/apps/statmaps/templates/statmaps/compare_search.html
@@ -29,13 +29,18 @@ function setAttributes(el, attrs) {
 }
 
 setAttributes(a, {"class": "btn btn-warning", "disabled": "true"});
-setAttributes(image_a,{"style": "float:right; margin-right:40px; font-weight:800; color:LightSeaGreen;", "href": "{{ image_url }}"});
+setAttributes(image_a,{"style": "float:right; margin-right:40px; font-weight:800;", "href": "{{ image_url }}"});
 
 a.appendChild(document.createTextNode(["{{ images_processing }} images still processing"]));
 image_a.appendChild(document.createTextNode(["{{ image_title }}"]));
 li.appendChild(a)
 portfolio_filter[0].appendChild(li.appendChild(image_a));
 
+// change oranges to NeuroVault blue
+var text = document.getElementsByTagName("span")
+for (i = 0; i < text.length; i++) { 
+  setAttributes(text[i],{"style":"color:#0088cc;"});
+}
 </script>
 
 {% endblock %}

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -750,24 +750,30 @@ def find_similar(request,pk):
     png_img_paths = [os.path.join(os.path.split(image_paths[i])[0],
                                   png_img_names[i]) for i in range(0,len(image_paths))]
     tags = [[str(image.map_type)] for image in images]
-    image_names = ["%s:%s ,%s" % (image.name,image.collection.name,
-                                  image.map_type) for image in images]
+    
+    # The top text will be the collection name, the bottom text the image name
+    bottom_text = ["%s" % (image.name) for image in images]
+    top_text = ["%s" % (image.collection.name) for image in images]
     compare_url = "/images/compare"  # format will be prefix/[query_id]/[other_id]
     image_url = "/images"  # format will be prefix/[other_id]
-
+    image_title = format_image_collection_names(image_name=image1.name,
+                                                       collection_name=image1.collection.name,
+                                                       map_type=image1.map_type,total_length=125)
+    
     # Here is the query image
     query_png = os.path.join(os.path.split(image1.file.url)[0],"glass_brain_%s.png" % (image1.pk))
 
     # Do similarity search and return html to put in page, specify 100 max results, take absolute value of scores
     html_snippet = compare.similarity_search(image_scores=scores,tags=tags,png_paths=png_img_paths,
                                 button_url=compare_url,image_url=image_url,query_png=query_png,
-                                query_id=pk,image_names=image_names,image_ids=image_ids,
-                                max_results=100,absolute_value=True)
+                                query_id=pk,top_text=top_text,image_ids=image_ids,
+                                bottom_text=bottom_text,max_results=100,absolute_value=True)
 
     html = [h.strip("\n") for h in html_snippet]
     
     images_processing = StatisticMap.objects.filter(collection__private=False).count() - len(image_ids)
-    context = {'html': html,'images_processing':images_processing}
+    context = {'html': html,'images_processing':images_processing,
+               'image_title':image_title, 'image_url': '/images/%s' % (image1.pk) }
     return render(request, 'statmaps/compare_search.html', context)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ celery[redis]
 django-celery
 scikit-learn
 nilearn
--e git://github.com/vsoch/pybraincompare.git@e8951253df11446077150cb0dbc1be24c166599f#egg=pybraincompare
+-e git://github.com/vsoch/pybraincompare.git@bd9ffd491ef346e72eae918ed43217a6cf0a69cc#egg=pybraincompare
 django-parsley
 django-cleanup
 django-chosen

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ celery[redis]
 django-celery
 scikit-learn
 nilearn
--e git://github.com/vsoch/pybraincompare.git@bd9ffd491ef346e72eae918ed43217a6cf0a69cc#egg=pybraincompare
+-e git://github.com/vsoch/pybraincompare.git@7d90af2f3c81a5c59f3af701fdb57c0a99525882#egg=pybraincompare
 django-parsley
 django-cleanup
 django-chosen


### PR DESCRIPTION
This will do slight tweaks to the "find similar" interface, including:

- Write the name of the map and collection it belongs to on top
- Dedicate more space for the names of the maps presented

The image collection name is displayed at the top of the image, and the name on the bottom, next to the score. The query image is also titled, with the title linking back to the query image. The updates to pybraincompare can be [viewed here](https://github.com/vsoch/pybraincompare/commit/bd9ffd491ef346e72eae918ed43217a6cf0a69cc)