### PR TITLE
Update/image comparison Tweaks

### DIFF
--- a/neurovault/apps/statmaps/templates/statmaps/compare_images.html
+++ b/neurovault/apps/statmaps/templates/statmaps/compare_images.html
@@ -10,6 +10,12 @@ var addthis_config = {
 {% endblock %}
 {% block content %}
 
+    {% if warnings %}
+       {% for warning in warnings %}
+        <div class="alert alert-danger" style="width:90%; margin-bottom:5px; margin-top:5px">{{ warning }}</div>   
+       {% endfor %}
+    {% endif %}
+
  {% autoescape off %}
     {% for snippet in html %}
        {{ snippet }}

--- a/neurovault/apps/statmaps/utils.py
+++ b/neurovault/apps/statmaps/utils.py
@@ -1,28 +1,30 @@
-import os
-import tempfile
-import subprocess
-import shutil
-import numpy as np
-import string
-import random
-from neurovault.apps.statmaps.models import Collection, NIDMResults, StatisticMap
-from neurovault import settings
-import urllib2
-from lxml import etree
-from datetime import datetime,date
-import cortex
-import pytz
-import errno
+from neurovault.apps.statmaps.models import Collection, NIDMResults, StatisticMap, Comparison
+from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
-import nibabel as nib
-from django.core.files.base import ContentFile
-from django.core.files.uploadedfile import InMemoryUploadedFile
-from ast import literal_eval
-from subprocess import CalledProcessError
 from django.core.exceptions import ValidationError
+from django.core.files.base import ContentFile
+from subprocess import CalledProcessError
+from datetime import datetime,date
+from neurovault import settings
+from django.db.models import Q
+from ast import literal_eval
+from scipy.misc import comb
+from lxml import etree
+import nibabel as nib
+import numpy as np
+import subprocess
+import tempfile
+import urllib2
 import zipfile
 import pickle
+import shutil
+import string
+import random
+import cortex
+import errno
+import pytz
+import os
 
 # see CollectionRedirectMiddleware
 class HttpRedirectException(Exception):
@@ -460,12 +462,38 @@ def not_in_mni(nii, plot=False):
     
     return ret, perc_mask_covered, perc_voxels_outside_of_mask
 
-# Returns images still processing
-def count_images_processing():
-    
-    # Count the number of images still processing
-    number_stat_maps = StatisticMap.objects.filter(collection__private=False)
-    # First use same filters used to determine if should calculate comparison
-    number_stat_maps = number_stat_maps.filter(is_thresholded=False).exclude(polymorphic_ctype__model__in=['image','atlas'])
-    # Images still processing in this set have transform = None
-    return number_stat_maps.filter(transform=None).count()
+
+# QUERY FUNCTIONS -------------------------------------------------------------------------------
+
+# Returns number of total comparisons, with public, not thresholded maps
+def count_existing_comparisons(pk1=None):
+    return get_existing_comparisons(pk1).count()
+
+# Returns number of total comparisons possible
+def count_possible_comparisons(pk1=None):
+    if pk1!=None:
+        # Comparisons possible for one pk is the number of other pks
+        return StatisticMap.objects.filter(is_thresholded=False,collection__private=False).exclude(pk=pk1).count()
+
+    else:
+        # Comparisons possible across entire database is N combinations of k=2 things
+        N = StatisticMap.objects.filter(is_thresholded=False,collection__private=False).count()
+        k = 2
+        return int(comb(N, k))
+
+# Returns image comparisons still processing for a given pk
+def count_processing_comparisons(pk1):
+    return count_possible_comparisons(pk1) - count_existing_comparisons(pk1)
+
+
+# Returns existing comparisons for specific pk, or entire database
+def get_existing_comparisons(pk1=None):
+    threshold_pks = StatisticMap.objects.filter(is_thresholded=True).values_list("pk",flat=True)
+    if pk1!=None:
+        comparisons = Comparison.objects.filter(Q(image1__pk=pk1) | Q(image2__pk=pk1), 
+                     image1__collection__private=False,
+                     image2__collection__private=False)
+    else:
+        comparisons = Comparison.objects.filter(image1__collection__private=False,
+                                                image2__collection__private=False) 
+    return comparisons.exclude(image1__id__in=threshold_pks,image2__id__in=threshold_pks)

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -11,7 +11,8 @@ from neurovault.apps.statmaps.utils import split_filename, generate_pycortex_vol
     generate_pycortex_static, generate_url_token, HttpRedirectException, get_paper_properties, \
     get_file_ctime, detect_afni4D, split_afni4D_to_3D, splitext_nii_gz, mkdir_p, \
     send_email_notification, populate_nidm_results, get_server_url, populate_feat_directory, \
-    detect_feat_directory, format_image_collection_names, count_images_processing
+    detect_feat_directory, format_image_collection_names, count_existing_comparisons, \
+    count_processing_comparisons, get_existing_comparisons
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse
 from django.db.models import Q, Count
@@ -789,21 +790,15 @@ def find_similar(request,pk):
     # Search only enabled if the image is not thresholded
     if image1.is_thresholded == False:
 
-        # Count the number of comparisons that we have to determine max that we can return, query takes 0.0014 sec
-        comparisons = Comparison.objects.filter(Q(image1=image1) | Q(image2=image1),
-                  image1__collection__private=False, 
-                  image2__collection__private=False)   # below takes 0.189, needs to be optimized
-        #comparisons = [comp for comp in comparisons if comp.image1.is_thresholded==False and comp.image2.is_thresholded==False]        
-        number_comparisons = len(comparisons)        
+        # Count the number of comparisons that we have to determine max that we can return
+        number_comparisons = count_existing_comparisons(pk)
 
         max_results = 100
         if number_comparisons < 100:
           max_results = number_comparisons
 
         # Get only # max_results similarity calculations for this image, and ids of other images
-        comparisons = Comparison.objects.filter(Q(image1=image1) | Q(image2=image1),
-                  image1__collection__private=False, 
-                  image2__collection__private=False).extra(select={"abs_score": "abs(similarity_score)"}).order_by("-abs_score")[0:max_results] # "-" indicates descending
+        comparisons = get_existing_comparisons(pk).extra(select={"abs_score": "abs(similarity_score)"}).order_by("-abs_score")[0:max_results] # "-" indicates descending
 
         images = [image1]
         scores = [1] # pearsonr
@@ -844,7 +839,7 @@ def find_similar(request,pk):
         html = [h.strip("\n") for h in html_snippet]
     
         # Get the number of images still processing
-        images_processing = count_images_processing()
+        images_processing = count_processing_comparisons(pk)
 
         context = {'html': html,'images_processing':images_processing,
                    'image_title':image_title, 'image_url': '/images/%s' % (image1.pk) }


### PR DESCRIPTION
This pull request should do some tweaks to the initial update/image comparison:

- The image counter was not accurately counting the images still processing. We now have functions in utils to both count and get images processing and existing, taking into account StatisticMaps and NIDMResultStatisticMaps
- There was a format character error within pybraincompare that was just fixed (this error would only generate in Opbeat and we should check if/when the production is updated)
- There is now a warning on scatterplot atlas page if either of the images is thresholded.

We also should close #133 - work done from previous PR.