### PR TITLE
Fix/image comparison

### DIFF
--- a/neurovault/apps/statmaps/migrations/0041_cognitive_atlas_ondelete_do_nothing.py
+++ b/neurovault/apps/statmaps/migrations/0041_cognitive_atlas_ondelete_do_nothing.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
@@ -14,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='statisticmap',
             name='cognitive_paradigm_cogatlas',
-            field=models.ForeignKey(on_delete=b'DO_NOTHING', verbose_name=b'Cognitive Paradigm', to='statmaps.CognitiveAtlasTask', help_text=b"Task (or lack of it) performed by the subjects in the scanner described using <a href='http://www.cognitiveatlas.org/'>Cognitive Atlas</a> terms", null=True),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.DO_NOTHING, verbose_name=b'Cognitive Paradigm', to='statmaps.CognitiveAtlasTask', help_text=b"Task (or lack of it) performed by the subjects in the scanner described using <a href='http://www.cognitiveatlas.org/'>Cognitive Atlas</a> terms", null=True),
             preserve_default=True,
         ),
     ]

--- a/neurovault/apps/statmaps/migrations/0041_cognitive_atlas_ondelete_do_nothing.py
+++ b/neurovault/apps/statmaps/migrations/0041_cognitive_atlas_ondelete_do_nothing.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('statmaps', '0040_add_comparison_index'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='statisticmap',
+            name='cognitive_paradigm_cogatlas',
+            field=models.ForeignKey(on_delete=b'DO_NOTHING', verbose_name=b'Cognitive Paradigm', to='statmaps.CognitiveAtlasTask', help_text=b"Task (or lack of it) performed by the subjects in the scanner described using <a href='http://www.cognitiveatlas.org/'>Cognitive Atlas</a> terms", null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -408,8 +408,7 @@ class StatisticMap(BaseStatisticMap):
     smoothness_fwhm = models.FloatField(help_text="Noise smoothness for statistical inference; this is the estimated smoothness used with Random Field Theory or a simulation-based inference method.", verbose_name="Smoothness FWHM", null=True, blank=True)
     contrast_definition = models.CharField(help_text="Exactly what terms are subtracted from what? Define these in terms of task or stimulus conditions (e.g., 'one-back task with objects versus zero-back task with objects') instead of underlying psychological concepts (e.g., 'working memory').", verbose_name="Contrast definition", max_length=200, null=True, blank=True)
     contrast_definition_cogatlas = models.CharField(help_text="Link to <a href='http://www.cognitiveatlas.org/'>Cognitive Atlas</a> definition of this contrast", verbose_name="Cognitive Atlas definition", max_length=200, null=True, blank=True)
-    cognitive_paradigm_cogatlas = models.ForeignKey(CognitiveAtlasTask, help_text="Task (or lack of it) performed by the subjects in the scanner described using <a href='http://www.cognitiveatlas.org/'>Cognitive Atlas</a> terms", verbose_name="Cognitive Paradigm", null=True, blank=False)
-
+    cognitive_paradigm_cogatlas = models.ForeignKey(CognitiveAtlasTask, help_text="Task (or lack of it) performed by the subjects in the scanner described using <a href='http://www.cognitiveatlas.org/'>Cognitive Atlas</a> terms", verbose_name="Cognitive Paradigm", null=True, blank=False, on_delete="DO_NOTHING")
 
 class NIDMResults(BaseCollectionItem):
     ttl_file = models.FileField(upload_to=upload_nidm_to,

--- a/neurovault/apps/statmaps/tasks.py
+++ b/neurovault/apps/statmaps/tasks.py
@@ -92,8 +92,8 @@ def run_voxelwise_pearson_similarity(pk1):
     comp_qs = imgs.exclude(polymorphic_ctype__model__in=['image','atlas']).order_by('id')
     for comp_img in comp_qs:
         iargs = sorted([comp_img.pk,pk1]) 
-        
-        save_voxelwise_pearson_similarity.apply_async(iargs)  # Default uses transformation, transformation = True
+        if comp_img.is_thresholded == False:
+            save_voxelwise_pearson_similarity.apply_async(iargs)  # Default uses transformation, transformation = True
 
 
 @shared_task

--- a/neurovault/apps/statmaps/tests/test_comparison.py
+++ b/neurovault/apps/statmaps/tests/test_comparison.py
@@ -25,28 +25,28 @@ class ComparisonTestCase(TestCase):
         self.tmpdir = tempfile.mkdtemp()
         app_path = os.path.abspath(os.path.dirname(__file__))
         self.u1 = User.objects.create(username='neurovault')
-        comparisonCollection = Collection(name='comparisonCollection',owner=self.u1)
-        comparisonCollection.save()
+        self.comparisonCollection = Collection(name='comparisonCollection',owner=self.u1)
+        self.comparisonCollection.save()
         
-        image1 = StatisticMap(name='image1', description='',collection=comparisonCollection)
+        image1 = StatisticMap(name='image1', description='',collection=self.comparisonCollection)
         image1.file = SimpleUploadedFile('VentralFrontal_thr75_summaryimage_2mm.nii.gz', file(os.path.join(app_path,'test_data/api/VentralFrontal_thr75_summaryimage_2mm.nii.gz')).read())
         image1.save()
         self.pk1 = image1.id
         
         # Image 2 is equivalent to 1, so pearson should be 1.0
-        image2 = StatisticMap(name='image1_copy', description='',collection=comparisonCollection)
+        image2 = StatisticMap(name='image1_copy', description='',collection=self.comparisonCollection)
         image2.file = SimpleUploadedFile('VentralFrontal_thr75_summaryimage_2mm.nii.gz', file(os.path.join(app_path,'test_data/api/VentralFrontal_thr75_summaryimage_2mm.nii.gz')).read())
         image2.save()
         self.pk1_copy = image2.id
         
         bricks = split_afni4D_to_3D(nibabel.load(os.path.join(app_path,'test_data/TTatlas.nii.gz')),tmp_dir=self.tmpdir)
         
-        image3 = StatisticMap(name='image2', description='',collection=comparisonCollection)
+        image3 = StatisticMap(name='image2', description='',collection=self.comparisonCollection)
         image3.file = SimpleUploadedFile('brik1.nii.gz', file(bricks[0][1]).read())
         image3.save()
         self.pk2 = image3.id
         
-        image4 = StatisticMap(name='image3', description='',collection=comparisonCollection)
+        image4 = StatisticMap(name='image3', description='',collection=self.comparisonCollection)
         image4.file = SimpleUploadedFile('brik2.nii.gz', file(bricks[1][1]).read())
         image4.save()
         self.pk3 = image4.id

--- a/neurovault/apps/statmaps/tests/test_thresholded_comparisons.py
+++ b/neurovault/apps/statmaps/tests/test_thresholded_comparisons.py
@@ -1,0 +1,107 @@
+from neurovault.apps.statmaps.utils import count_existing_comparisons, get_existing_comparisons, count_processing_comparisons
+from neurovault.apps.statmaps.models import Image, Comparison, Similarity, User, Collection, StatisticMap
+from neurovault.apps.statmaps.tests.utils import save_statmap_form, save_atlas_form
+from numpy.testing import assert_array_equal, assert_almost_equal, assert_equal
+from django.core.files.uploadedfile import SimpleUploadedFile
+from neurovault.apps.statmaps.utils import split_afni4D_to_3D
+from neurovault.apps.statmaps.tests.utils import clearDB
+from django.shortcuts import get_object_or_404
+from django.db import IntegrityError
+from django.test import TestCase
+import tempfile
+import nibabel
+import shutil
+import errno
+import os
+
+class QueryTestCase(TestCase):
+    pk1 = None
+    pk2 = None
+    pk3 = None
+    pk4 = None
+    pearson_metric = None
+    
+    def setUp(self):
+        print "\n#### TESTING THRESHOLDED IMAGES IN COMPARISON\n"
+        self.tmpdir = tempfile.mkdtemp()
+        self.app_path = os.path.abspath(os.path.dirname(__file__))
+        self.u1 = User.objects.create(username='neurovault')
+        self.comparisonCollection = Collection(name='comparisonCollection',owner=self.u1)
+        self.comparisonCollection.save()
+        
+        # Image 1 is an atlas
+        print "Adding atlas image..."
+        nii_path = os.path.join(self.app_path,"test_data/api/VentralFrontal_thr75_summaryimage_2mm.nii.gz")
+        xml_path = os.path.join(self.app_path,"test_data/api/VentralFrontal_thr75_summaryimage_2mm.xml")
+        image1 = save_atlas_form(nii_path=nii_path,xml_path=xml_path,collection = self.comparisonCollection)
+        self.pk1 = image1.id
+
+        # Image 2 is a statistical map
+        print "Adding statistical map..."
+        image_path = os.path.join(self.app_path,'test_data/statmaps/beta_0001.nii.gz')
+        image2 = save_statmap_form(image_path=image_path,collection = self.comparisonCollection)
+        self.pk2 = image2.id
+        
+        # Image 3 is a thresholded statistical map
+        print "Adding thresholded statistical map..."
+        image_paths = [os.path.join(self.app_path,'test_data/statmaps/box_0b_vs_1b.img'),
+                       os.path.join(self.app_path,'test_data/statmaps/box_0b_vs_1b.hdr')]
+        image3 = save_statmap_form(image_path=image_paths, collection = self.comparisonCollection,ignore_file_warning=True)
+        self.pk3 = image3.id
+
+        # Create similarity object
+        Similarity.objects.update_or_create(similarity_metric="pearson product-moment correlation coefficient",
+                                         transformation="voxelwise",
+                                         metric_ontology_iri="http://webprotege.stanford.edu/RCS8W76v1MfdvskPLiOdPaA",
+                                         transformation_ontology_iri="http://webprotege.stanford.edu/R87C6eFjEftkceScn1GblDL")
+        self.pearson_metric = Similarity.objects.filter(similarity_metric="pearson product-moment correlation coefficient",
+                                         transformation="voxelwise",
+                                         metric_ontology_iri="http://webprotege.stanford.edu/RCS8W76v1MfdvskPLiOdPaA",
+                                         transformation_ontology_iri="http://webprotege.stanford.edu/R87C6eFjEftkceScn1GblDL")        
+        
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+        clearDB()
+
+    def test_thresholded_image_comparison(self):
+        # There should be no comparisons for a thresholded image
+        print "testing comparisons for thresholded images"
+        assert_equal(0,count_existing_comparisons(self.pk3))
+
+        # There should be no comparisons for an atlas
+        print "testing comparisons for atlases"
+        assert_equal(0,count_existing_comparisons(self.pk1))
+
+        # There should be no comparisons for statistical map because no other statistical maps
+        print "testing comparisons for statistical maps"
+        assert_equal(0,count_existing_comparisons(self.pk2))
+
+        # Add another statistical map   
+        image_path = os.path.join(self.app_path,'test_data/statmaps/motor_lips.nii.gz')
+        image4 = save_statmap_form(image_path=image_path,collection = self.comparisonCollection)
+        self.pk4 = image4.id
+          
+        # There should STILL be no comparisons for a thresholded image
+        print "testing comparisons for thresholded images"
+        assert_equal(0,count_existing_comparisons(self.pk3))
+
+        # There should STILL be no comparisons for an of the atlas
+        print "testing comparisons for atlases"
+        assert_equal(0,count_existing_comparisons(self.pk1))
+
+        # There should now be one comparison for each statistical map, two total
+        print "testing comparisons for statistical maps"
+        print Comparison.objects.all()
+        assert_equal(1,count_existing_comparisons(self.pk2))
+        assert_equal(1,count_existing_comparisons(self.pk4))
+        assert_equal(1,count_existing_comparisons())
+
+        # This is the call that find_similar users to get images
+        comparisons =  get_existing_comparisons(self.pk4)
+        for comp in comparisons:
+            pk1=comp.image1.pk
+            pk2=comp.image2.pk          
+            im1 = Image.objects.get(pk=pk1)
+            im2 = Image.objects.get(pk=pk2)
+            assert_equal(im1.is_thresholded,False)
+            assert_equal(im2.is_thresholded,False)

--- a/neurovault/apps/statmaps/tests/utils.py
+++ b/neurovault/apps/statmaps/tests/utils.py
@@ -2,6 +2,9 @@ import os
 import shutil
 from neurovault.settings import PRIVATE_MEDIA_ROOT
 from neurovault.apps.statmaps.models import Collection, Image
+from django.core.files.uploadedfile import SimpleUploadedFile
+from neurovault.apps.statmaps.forms import StatisticMapForm, AtlasForm
+
 
 def clearDB():
     Image.objects.all().delete()
@@ -16,3 +19,44 @@ def clearDB():
                     shutil.rmtree(file_path)
             except Exception, e:
                 print e
+
+
+
+def save_statmap_form(image_path,collection,ignore_file_warning=False):
+
+    if isinstance(image_path,list):
+        image_name = image_path[0]
+    else:
+        image_name = image_path
+    post_dict = {
+        'name': image_name,
+        'cognitive_paradigm_cogatlas': 'trm_4f24126c22011',
+        'modality':'fMRI-BOLD',
+        'map_type': 'T',
+        'collection':collection.pk,
+        'ignore_file_warning': ignore_file_warning
+    }
+    # If image path is a list, we have img/hdr
+    if isinstance(image_path,list):
+        file_dict = {'file': SimpleUploadedFile(image_path[0], open(image_path[0]).read()),
+                     'hdr_file': SimpleUploadedFile(image_path[1], open(image_path[1]).read())}
+    else:
+        file_dict = {'file': SimpleUploadedFile(image_path, open(image_path).read())}
+    form = StatisticMapForm(post_dict, file_dict)
+    return form.save()
+
+
+def save_atlas_form(nii_path,xml_path,collection,ignore_file_warning=False):
+
+    post_dict = {
+        'name': nii_path,
+        'map_type': 'Atlas',
+        'collection':collection.pk,
+        'ignore_file_warning': ignore_file_warning
+    }
+    file_dict = {'file': SimpleUploadedFile(nii_path, open(nii_path).read()),
+                     'label_description_file': SimpleUploadedFile(xml_path, open(xml_path).read())}
+    form = AtlasForm(post_dict, file_dict)
+    return form.save()
+
+

--- a/neurovault/apps/statmaps/utils.py
+++ b/neurovault/apps/statmaps/utils.py
@@ -502,4 +502,4 @@ def get_existing_comparisons(pk1=None):
     else:
         comparisons = Comparison.objects.filter(image1__collection__private=False,
                                                 image2__collection__private=False) 
-    return comparisons.exclude(image1__id__in=threshold_pks,image2__id__in=threshold_pks)
+    return comparisons.exclude(image1__id__in=threshold_pks).exclude(image2__id__in=threshold_pks)

--- a/neurovault/urls.py
+++ b/neurovault/urls.py
@@ -2,12 +2,12 @@ from django.conf.urls import patterns, include, url
 from django.conf import settings
 from django.contrib import admin
 from neurovault.apps.statmaps.models import Image, Collection, StatisticMap,\
-    Atlas, NIDMResults, NIDMResultStatisticMap
+    Atlas, NIDMResults, NIDMResultStatisticMap, CognitiveAtlasTask
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.conf.urls.static import static
 from rest_framework.filters import DjangoFilterBackend
 from lxml.etree import xmlfile
-from rest_framework.relations import StringRelatedField
+from rest_framework.relations import StringRelatedField, PrimaryKeyRelatedField
 admin.autodiscover()
 from django.contrib.auth.models import User, Group
 from rest_framework import viewsets, routers, serializers, mixins, generics
@@ -135,6 +135,7 @@ class StatisticMapSerializer(serializers.HyperlinkedModelSerializer):
     collection = HyperlinkedRelatedURL(read_only=True)
     url = HyperlinkedImageURL(source='get_absolute_url')
     cognitive_paradigm_cogatlas = StringRelatedField(read_only=True)
+    cognitive_paradigm_cogatlas_id = PrimaryKeyRelatedField(read_only=True, source="cognitive_paradigm_cogatlas")
 
     class Meta:
         model = StatisticMap


### PR DESCRIPTION
This PR includes the following:

- Adding [on_delete=DO_NOTHING](https://github.com/vsoch/NeuroVault/blob/fix/image_comparison/neurovault/apps/statmaps/models.py#L421) to the Cognitive_Atlas_Task to ensure that deleting an image does not delete the associated task
- moving the [run_voxelwise_pearson_similarity](https://github.com/vsoch/NeuroVault/blob/fix/image_comparison/neurovault/apps/statmaps/models.py#L381) to be done under "BaseStatisticMap" instead of Image so that we don't calculate comparisons outside of StatisticalMap instances.
- A check that [the image for which comparisons will be calculated is not thresholded](https://github.com/vsoch/NeuroVault/blob/fix/image_comparison/neurovault/apps/statmaps/models.py#L379) is made here as well.
- Within the task to calculate comparisons, we [check that each image2 is not thresholded](https://github.com/vsoch/NeuroVault/blob/fix/image_comparison/neurovault/apps/statmaps/tasks.py#L95)
- [Test functions in utils](https://github.com/vsoch/NeuroVault/blob/fix/image_comparison/neurovault/apps/statmaps/tests/utils.py#L25) to save atlas and statisticMap forms, since this is done pretty often
- [Test of the above](https://github.com/vsoch/NeuroVault/blob/fix/image_comparison/neurovault/apps/statmaps/tests/test_thresholded_comparisons.py) - that we aren't calculating comparisons for thresholded images!

