### PR TITLE
Fix API by adding pagination

### DIFF
--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -262,8 +262,7 @@ class Image(PolymorphicModel, BaseCollectionItem):
         try:
             url =  self.thumbnail.url
         except ValueError:
-            url = os.path.abspath(os.path.join(neurovault.settings.BASE_DIR,
-                                 "static","images","glass_brain_empty.jpg"))
+            url = os.path.abspath(os.path.join("/static","images","glass_brain_empty.jpg"))
         return url         
 
     @classmethod

--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -19,6 +19,7 @@ from gzip import GzipFile
 from django import forms
 from xml import etree
 import nibabel as nb
+import neurovault
 import urllib2
 import shutil
 import os
@@ -256,6 +257,14 @@ class Image(PolymorphicModel, BaseCollectionItem):
             return_args.insert(0,str(self.collection.private_token))
             url_name = 'private_image_details'
         return reverse(url_name, args=return_args)
+
+    def get_thumbnail_url(self):
+        try:
+            url =  self.thumbnail.url
+        except ValueError:
+            url = os.path.abspath(os.path.join(neurovault.settings.BASE_DIR,
+                                 "static","images","glass_brain_empty.jpg"))
+        return url         
 
     @classmethod
     def create(cls, my_file, my_file_name, my_name, my_desc, my_collection_pk, my_map_type):

--- a/neurovault/apps/statmaps/tests/test_api.py
+++ b/neurovault/apps/statmaps/tests/test_api.py
@@ -55,10 +55,7 @@ class Test_Atlas_APIs(TestCase):
 
     def test_query_region_out_of_order_indices(self):
         
-        # First test, tell user testing API
-        print "\n#### TESTING API\n"
-
-        print "Assessing equality of ordered vs. unordered atlas query..."
+        print "\nAssessing equality of ordered vs. unordered atlas query..."
         atlas_dir = os.path.join(self.test_path, 'test_data/api')
         tree = ET.parse(os.path.join(atlas_dir,'VentralFrontal_thr75_summaryimage_2mm.xml'))
         root = tree.getroot()
@@ -79,7 +76,7 @@ class Test_Atlas_APIs(TestCase):
             print "Equality of lists for region %s: %s" %(region,orderedSorted==unorderedSorted) 
             self.assertEqual(orderedSorted, unorderedSorted)
 
-        print "Assessing consistency of results for regional query..."             
+        print "\nAssessing consistency of results for regional query..."             
         testRegions = {'6v':[(58.00,-4.00,18.00),(62.00,6.00,30.00)], 
                        'fop':[(56.00,20.00,24.00),(34.00,18.00,30.00)], 
                        'fpm':[(8.00,62.00,10.00),(10.00,62.00,-16.00)]}
@@ -93,7 +90,7 @@ class Test_Atlas_APIs(TestCase):
 
 
     def test_out_of_order_indices(self):
-        print "Assessing consistency of results for coordinate query..."             
+        print "\nAssessing consistency of results for coordinate query..."             
         testRegions = {'6v':[(58.00,-4.00,18.00),(62.00,6.00,30.00)],
                        'fop':[(56.00,20.00,24.00),(34.00,18.00,30.00)],
                        'fpm':[(8.00,62.00,10.00),(10.00,62.00,-16.00)]}        
@@ -110,7 +107,7 @@ class Test_Atlas_APIs(TestCase):
 ### General API Tests
 
     def test_atlases(self):
-        print "Checking that atlas images are returned by atlas api..."
+        print "\nChecking that atlas images are returned by atlas api..."
         url = '/api/atlases/'
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertTrue('.nii.gz' in response['results'][0][u'file'])
@@ -118,27 +115,27 @@ class Test_Atlas_APIs(TestCase):
         self.assertTrue(u'orderedAtlas' in names)
 
     def test_atlases_pk(self):
-        print "Testing atlas query with specific atlas pk...."
+        print "\nTesting atlas query with specific atlas pk...."
         url = '/api/atlases/%d/' % self.unorderedAtlas.pk
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertTrue('.nii.gz' in response[u'file'])
         self.assertEqual(response['name'], u'unorderedAtlas')
 
     def test_atlases_datatable(self):
-        print "Testing atlas datatable query...."
+        print "\nTesting atlas datatable query...."
         url = '/api/atlases/%d/datatable/' % self.unorderedAtlas.pk
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertTrue('.xml' in response['aaData'][1][1])
 
     def test_atlases_regions_table(self):
-        print "Testing atlas regions table query...."
+        print "\nTesting atlas regions table query...."
         url = '/api/atlases/%d/regions_table/' % self.unorderedAtlas.pk
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertEqual(response['aaData'][2][1], u'fop')
         self.assertEqual(response['aaData'][11][1], u'46')
 
     def test_collections(self):
-        print "Testing collections API...."
+        print "\nTesting collections API...."
         url = '/api/collections/'
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertEqual(response['results'][0][u'nidm_results'][0][u'name'], u'fsl.nidm')
@@ -161,7 +158,7 @@ class Test_Atlas_APIs(TestCase):
         self.assertEqual(collection_name, u'Collection1' )
 
     def test_images(self):
-        print "Testing images API...."
+        print "\nTesting images API...."
         url = '/api/images/'
         response = json.loads(self.client.get(url, follow=True).content)
         names = [item[u'name'] for item in response['results']]
@@ -180,7 +177,7 @@ class Test_Atlas_APIs(TestCase):
         self.assertTrue('http' in response['aaData'][1][1])
 
     def test_nidm_results(self):
-        print "Testing NIDM results API...."
+        print "\nTesting NIDM results API...."
         url = '/api/nidm_results/'
         response = json.loads(self.client.get(url, follow=True).content)
         descriptions = [item[u'description'] for item in response['results'][0][u'statmaps']]
@@ -197,7 +194,7 @@ class Test_Atlas_APIs(TestCase):
 ### Pagination
 
     def test_pagination(self):
-        print "Testing API pagination..."
+        print "\nTesting API pagination..."
         print "Max limit is set to %s" %(StandardResultPagination.max_limit)
         self.assertEqual(1000,StandardResultPagination.max_limit)
         print "Default limit is set to %s" %(StandardResultPagination.default_limit)

--- a/neurovault/apps/statmaps/tests/test_api.py
+++ b/neurovault/apps/statmaps/tests/test_api.py
@@ -169,7 +169,8 @@ class Test_Atlas_APIs(TestCase):
         url = '/api/images/%d/' % self.Image1.pk
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertTrue('http' in response['collection'])
-        self.assertEqual(response['name'], u'/opt/nv_env/NeuroVault/neurovault/apps/statmaps/tests/test_data/statmaps/motor_lips.nii.gz')
+        image_path = os.path.join(self.test_path,'test_data/statmaps/motor_lips.nii.gz')
+        self.assertEqual(response['name'], image_path)
 
     def test_images_datatable(self):
         url = '/api/images/%d/datatable/' % self.Image2.pk

--- a/neurovault/apps/statmaps/tests/test_api.py
+++ b/neurovault/apps/statmaps/tests/test_api.py
@@ -1,14 +1,13 @@
+from neurovault.apps.statmaps.tests.utils import clearDB, save_atlas_form, save_statmap_form, save_nidm_form
+from neurovault.apps.statmaps.models import Atlas, Collection, Image, StatisticMap
+from neurovault.apps.statmaps.urls import StandardResultPagination
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.contrib.auth.models import User
 from django.test import TestCase, Client
 import xml.etree.ElementTree as ET
-from neurovault.apps.statmaps.models import Atlas, Collection, Image,\
-    StatisticMap
-import os.path
-from django.contrib.auth.models import User
 from operator import itemgetter
-from django.core.files.uploadedfile import SimpleUploadedFile
-from neurovault.apps.statmaps.forms import NIDMResultsForm
+import os.path
 import json
-from .utils import clearDB
 
 class Test_Atlas_APIs(TestCase):
     def setUp(self):
@@ -19,106 +18,138 @@ class Test_Atlas_APIs(TestCase):
         self.Collection1 = Collection(name='Collection1',owner=self.user)
         self.Collection1.save()
         self.unorderedAtlas = Atlas(name='unorderedAtlas', description='',collection=self.Collection1)
-        self.unorderedAtlas.file = SimpleUploadedFile('VentralFrontal_thr75_summaryimage_2mm.nii.gz', file(os.path.join(self.test_path,'test_data/api/VentralFrontal_thr75_summaryimage_2mm.nii.gz')).read())
-        self.unorderedAtlas.label_description_file = SimpleUploadedFile('test_VentralFrontal_thr75_summaryimage_2mm.xml', file(os.path.join(self.test_path,'test_data/api/unordered_VentralFrontal_thr75_summaryimage_2mm.xml')).read())
-        self.unorderedAtlas.save()
         
-        self.orderedAtlas = Atlas(name='orderedAtlas', collection=self.Collection1, label_description_file='VentralFrontal_thr75_summaryimage_2mm.xml')
-        self.orderedAtlas.file = SimpleUploadedFile('VentralFrontal_thr75_summaryimage_2mm.nii.gz', file(os.path.join(self.test_path,'test_data/api/VentralFrontal_thr75_summaryimage_2mm.nii.gz')).read())
-        self.orderedAtlas.label_description_file = SimpleUploadedFile('test_VentralFrontal_thr75_summaryimage_2mm.xml', file(os.path.join(self.test_path,'test_data/api/VentralFrontal_thr75_summaryimage_2mm.xml')).read())
-        self.orderedAtlas.save()
-        
-        self.Image1 = StatisticMap(name='Image1', collection=self.Collection1, file='motor_lips.nii.gz', map_type="Z")
-        self.Image1.file = SimpleUploadedFile('motor_lips.nii.gz', file(os.path.join(self.test_path,'test_data/statmaps/motor_lips.nii.gz')).read())
-        self.Image1.save()
-        
-        self.Image2 = StatisticMap(name='Image2', collection=self.Collection1, file='beta_0001.nii.gz', map_type="Other")
-        self.Image2.file = SimpleUploadedFile('beta_0001.nii.gz', file(os.path.join(self.test_path,'test_data/statmaps/beta_0001.nii.gz')).read())
-        self.Image2.save()
-        
-        
-        self.zip_file = open(os.path.join(self.test_path,'test_data/nidm/fsl.nidm.zip'), 'rb')
-        self.post_dict = {
-            'name': 'fsl_nidm',
-            'description':'{0} upload test'.format('fsl_nidm'),
-            'collection':self.Collection1.pk}
-        self.fname = os.path.basename(os.path.join(self.test_path,'test_data/nidm/fsl.nidm.zip'))
-        self.file_dict = {'zip_file': SimpleUploadedFile(self.fname, self.zip_file.read())}
-        self.zip_file.close()
-        self.form = NIDMResultsForm(self.post_dict, self.file_dict)
-        self.nidm = self.form.save()
-        
+        # Save new atlas object, unordered
+        print "Adding unordered and ordered atlas..."
+        nii_path = os.path.join(self.test_path,'test_data/api/VentralFrontal_thr75_summaryimage_2mm.nii.gz')
+        xml_path = os.path.join(self.test_path,'test_data/api/unordered_VentralFrontal_thr75_summaryimage_2mm.xml')
+        self.unorderedAtlas = save_atlas_form(nii_path=nii_path,
+                              xml_path=xml_path,
+                              collection=self.Collection1,
+                              name = "unorderedAtlas")
+        # Ordered
+        nii_path = os.path.join(self.test_path,'test_data/api/VentralFrontal_thr75_summaryimage_2mm.nii.gz')
+        xml_path = os.path.join(self.test_path,'test_data/api/VentralFrontal_thr75_summaryimage_2mm.xml')
+        self.orderedAtlas = save_atlas_form(nii_path=nii_path,
+                              xml_path=xml_path,
+                              collection=self.Collection1,
+                              name = "orderedAtlas")
+
+        # Statistical Map 1 and 2
+        print "Adding statistical maps..."
+        nii_path = os.path.join(self.test_path,'test_data/statmaps/motor_lips.nii.gz') 
+        self.Image1 = save_statmap_form(image_path=nii_path, collection=self.Collection1)
+        nii_path = os.path.join(self.test_path,'test_data/statmaps/beta_0001.nii.gz') 
+        self.Image2 = save_statmap_form(image_path=nii_path, collection=self.Collection1)
+  
+        # Zip file with nidm results
+        print "Adding nidm results..."
+        zip_file = os.path.join(self.test_path,'test_data/nidm/fsl.nidm.zip')  
+        self.nidm = save_nidm_form(zip_file=zip_file,collection=self.Collection1)
+            
+
     def tearDown(self):
         clearDB()
 
+### Atlas Query Tests
+
     def test_query_region_out_of_order_indices(self):
+        
+        # First test, tell user testing API
+        print "\n#### TESTING API\n"
+
+        print "Assessing equality of ordered vs. unordered atlas query..."
         atlas_dir = os.path.join(self.test_path, 'test_data/api')
         tree = ET.parse(os.path.join(atlas_dir,'VentralFrontal_thr75_summaryimage_2mm.xml'))
         root = tree.getroot()
         atlasRegions = [x.text.lower() for x in root.find('data').findall('label')]
         for region in atlasRegions:
-            orderedURL = 'http://127.0.0.1:8000/api/atlases/atlas_query_region/?region=%s&atlas=orderedAtlas&collection=Collection1' %region
+            orderedURL = 'http://127.0.0.1:8000/api/atlases/atlas_query_region/?region=%s&atlas=orderedAtlas&collection=Collection1' %(region)
             orderedResponse = self.client.get(orderedURL, follow=True)
-            unorderedURL = 'http://127.0.0.1:8000/api/atlases/atlas_query_region/?region=%s&atlas=unorderedAtlas&collection=Collection1' %region
+            unorderedURL = 'http://127.0.0.1:8000/api/atlases/atlas_query_region/?region=%s&atlas=unorderedAtlas&collection=Collection1' %(region)
             unorderedResponse = self.client.get(unorderedURL, follow=True)
             orderedList = eval(orderedResponse.content)['voxels']
             unorderedList = eval(unorderedResponse.content)['voxels']
- 
-            orderedTriples = [(orderedList[0][i],orderedList[1][i],orderedList[2][i]) for i in range(len(orderedList[0]))]
-            unorderedTriples = [(unorderedList[0][i],unorderedList[1][i],unorderedList[2][i]) for i in range(len(unorderedList[0]))]
+            orderedTriples = [(orderedList[0][i],orderedList[1][i],
+                               orderedList[2][i]) for i in range(len(orderedList[0]))]
+            unorderedTriples = [(unorderedList[0][i],unorderedList[1][i],
+                                 unorderedList[2][i]) for i in range(len(unorderedList[0]))]
             orderedSorted = sorted(orderedTriples, key=itemgetter(0))
             unorderedSorted = sorted(unorderedTriples, key=itemgetter(0))
-             
+            print "Equality of lists for region %s: %s" %(region,orderedSorted==unorderedSorted) 
             self.assertEqual(orderedSorted, unorderedSorted)
-             
-        testRegions = {'6v':[(58.00,-4.00,18.00),(62.00,6.00,30.00)], 'fop':[(56.00,20.00,24.00),(34.00,18.00,30.00)], 'fpm':[(8.00,62.00,10.00),(10.00,62.00,-16.00)]}
+
+        print "Assessing consistency of results for regional query..."             
+        testRegions = {'6v':[(58.00,-4.00,18.00),(62.00,6.00,30.00)], 
+                       'fop':[(56.00,20.00,24.00),(34.00,18.00,30.00)], 
+                       'fpm':[(8.00,62.00,10.00),(10.00,62.00,-16.00)]}
         for region, testVoxels in testRegions.items():
-            URL = 'http://127.0.0.1:8000/api/atlases/atlas_query_region/?region=%s&atlas=orderedAtlas&collection=Collection1' %region
+            URL = 'http://127.0.0.1:8000/api/atlases/atlas_query_region/?region=%s&atlas=orderedAtlas&collection=Collection1' %(region)
             response = self.client.get(URL, follow=True)
             voxelList = eval(response.content)['voxels']
             triples = [(voxelList[0][i],voxelList[1][i],voxelList[2][i]) for i in range(len(voxelList[0]))]
             for voxel in testVoxels:
                 self.assertTrue(voxel in triples)
+
+
     def test_out_of_order_indices(self):
-        testRegions = {'6v':[(58.00,-4.00,18.00),(62.00,6.00,30.00)], 'fop':[(56.00,20.00,24.00),(34.00,18.00,30.00)], 'fpm':[(8.00,62.00,10.00),(10.00,62.00,-16.00)]}
+        print "Assessing consistency of results for coordinate query..."             
+        testRegions = {'6v':[(58.00,-4.00,18.00),(62.00,6.00,30.00)],
+                       'fop':[(56.00,20.00,24.00),(34.00,18.00,30.00)],
+                       'fpm':[(8.00,62.00,10.00),(10.00,62.00,-16.00)]}        
+
         for region, testVoxels in testRegions.items():
             for triple in testVoxels:
-                X, Y, Z = triple[0], triple[1], triple[2]
-                URL = 'http://127.0.0.1:8000/api/atlases/atlas_query_voxel/?x=%s&y=%s&z=%s&atlas=orderedAtlas&collection=Collection1' % (X, Y, Z)
+                X, Y, Z = triple[0],triple[1],triple[2]
+                URL = 'http://127.0.0.1:8000/api/atlases/atlas_query_voxel/?x=%s&y=%s&z=%s&atlas=orderedAtlas&collection=Collection1' % (X,Y,Z)
                 response = self.client.get(URL, follow=True)
                 responseText = eval(response.content)
                 self.assertEqual(responseText, region)
     
+
+### General API Tests
+
     def test_atlases(self):
+        print "Checking that atlas images are returned by atlas api..."
         url = '/api/atlases/'
         response = json.loads(self.client.get(url, follow=True).content)
-        self.assertTrue('.nii.gz' in response[0][u'file'])
-        names = [item[u'name'] for item in response]
+        self.assertTrue('.nii.gz' in response['results'][0][u'file'])
+        names = [item[u'name'] for item in response['results']]
         self.assertTrue(u'orderedAtlas' in names)
+
     def test_atlases_pk(self):
+        print "Testing atlas query with specific atlas pk...."
         url = '/api/atlases/%d/' % self.unorderedAtlas.pk
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertTrue('.nii.gz' in response[u'file'])
         self.assertEqual(response['name'], u'unorderedAtlas')
+
     def test_atlases_datatable(self):
+        print "Testing atlas datatable query...."
         url = '/api/atlases/%d/datatable/' % self.unorderedAtlas.pk
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertTrue('.xml' in response['aaData'][1][1])
+
     def test_atlases_regions_table(self):
+        print "Testing atlas regions table query...."
         url = '/api/atlases/%d/regions_table/' % self.unorderedAtlas.pk
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertEqual(response['aaData'][2][1], u'fop')
         self.assertEqual(response['aaData'][11][1], u'46')
+
     def test_collections(self):
+        print "Testing collections API...."
         url = '/api/collections/'
         response = json.loads(self.client.get(url, follow=True).content)
-        self.assertEqual(response[0][u'nidm_results'][0][u'name'], u'fsl.nidm')
-        self.assertEqual(response[0][u'echo_time'], None)
+        self.assertEqual(response['results'][0][u'nidm_results'][0][u'name'], u'fsl.nidm')
+        self.assertEqual(response['results'][0][u'echo_time'], None)
+
     def test_collections_pk(self):
         url = '/api/collections/%d/' % self.Collection1.pk
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertTrue('-' in response['add_date'])
         self.assertTrue(isinstance(response['id'], int))
+
     def test_collections_datatable(self):
         url = '/api/collections/%d/datatable/' % self.Collection1.pk
         response = json.loads(self.client.get(url, follow=True).content)
@@ -128,29 +159,55 @@ class Test_Atlas_APIs(TestCase):
                 collection_name = prop[1]
                 break
         self.assertEqual(collection_name, u'Collection1' )
+
     def test_images(self):
+        print "Testing images API...."
         url = '/api/images/'
         response = json.loads(self.client.get(url, follow=True).content)
-        names = [item[u'name'] for item in response]
+        names = [item[u'name'] for item in response['results']]
         self.assertTrue(u'unorderedAtlas' in names)
         self.assertTrue(u'Z-Statistic Map: Generation' in names)
+
     def test_images_pk(self):
         url = '/api/images/%d/' % self.Image1.pk
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertTrue('http' in response['collection'])
-        self.assertEqual(response['name'], 'Image1')
+        self.assertEqual(response['name'], u'/opt/nv_env/NeuroVault/neurovault/apps/statmaps/tests/test_data/statmaps/motor_lips.nii.gz')
+
     def test_images_datatable(self):
         url = '/api/images/%d/datatable/' % self.Image2.pk
         response = json.loads(self.client.get(url, follow=True).content)
-        self.assertTrue('http' in response['aaData'][0][1])
+        self.assertTrue('http' in response['aaData'][1][1])
+
     def test_nidm_results(self):
+        print "Testing NIDM results API...."
         url = '/api/nidm_results/'
         response = json.loads(self.client.get(url, follow=True).content)
-        descriptions = [item[u'description'] for item in response[0][u'statmaps']]
+        descriptions = [item[u'description'] for item in response['results'][0][u'statmaps']]
         self.assertTrue('NIDM Results: fsl.nidm.zip > TStatistic.nii.gz' in descriptions)
-        self.assertEqual(response[0]['description'], u'fsl_nidm upload test')
+        self.assertEqual(response['results'][0]['description'], u'fsl_nidm upload test')
+
     def test_nidm_results_pk(self):
         url = '/api/nidm_results/%d/' % self.nidm.pk
         response = json.loads(self.client.get(url, follow=True).content)
         self.assertTrue('fsl.nidm.ttl' in response['ttl_file'])
         self.assertEqual(response['statmaps'][0][u'figure'], None)
+
+
+### Pagination
+
+    def test_pagination(self):
+        print "Testing API pagination..."
+        print "Max limit is set to %s" %(StandardResultPagination.max_limit)
+        self.assertEqual(1000,StandardResultPagination.max_limit)
+        print "Default limit is set to %s" %(StandardResultPagination.default_limit)
+        self.assertEqual(100,StandardResultPagination.default_limit)
+        print "Page size (equal to default) is set to %s" %(StandardResultPagination.PAGE_SIZE)
+        self.assertEqual(100,StandardResultPagination.PAGE_SIZE)
+
+        url = '/api/images/?limit=1'
+        response = json.loads(self.client.get(url, follow=True).content)
+        self.assertEqual(1,len(response['results']))
+        url = '/api/images/?limit=2'
+        response = json.loads(self.client.get(url, follow=True).content)
+        self.assertEqual(2,len(response['results']))

--- a/neurovault/apps/statmaps/tests/utils.py
+++ b/neurovault/apps/statmaps/tests/utils.py
@@ -1,9 +1,9 @@
-import os
-import shutil
-from neurovault.settings import PRIVATE_MEDIA_ROOT
+from neurovault.apps.statmaps.forms import StatisticMapForm, AtlasForm, NIDMResultsForm
 from neurovault.apps.statmaps.models import Collection, Image
 from django.core.files.uploadedfile import SimpleUploadedFile
-from neurovault.apps.statmaps.forms import StatisticMapForm, AtlasForm
+from neurovault.settings import PRIVATE_MEDIA_ROOT
+import shutil
+import os
 
 
 def clearDB():
@@ -46,10 +46,13 @@ def save_statmap_form(image_path,collection,ignore_file_warning=False):
     return form.save()
 
 
-def save_atlas_form(nii_path,xml_path,collection,ignore_file_warning=False):
+def save_atlas_form(nii_path,xml_path,collection,ignore_file_warning=False,name=None):
+
+    if name == None:
+        name = nii_path
 
     post_dict = {
-        'name': nii_path,
+        'name': name,
         'map_type': 'Atlas',
         'collection':collection.pk,
         'ignore_file_warning': ignore_file_warning
@@ -59,4 +62,18 @@ def save_atlas_form(nii_path,xml_path,collection,ignore_file_warning=False):
     form = AtlasForm(post_dict, file_dict)
     return form.save()
 
+
+def save_nidm_form(zip_file,collection,name=None):
+    
+    if name == None:
+        name = "fsl_nidm"
+    zip_file_obj = open(zip_file, 'rb')
+    post_dict = {'name': name,
+                 'description':'{0} upload test'.format('fsl_nidm'),
+                 'collection':collection.pk}
+    fname = os.path.basename(zip_file)
+    file_dict = {'zip_file': SimpleUploadedFile(fname, zip_file_obj.read())}
+    zip_file_obj.close()
+    form = NIDMResultsForm(post_dict, file_dict)
+    return form.save()
 

--- a/neurovault/apps/statmaps/urls.py
+++ b/neurovault/apps/statmaps/urls.py
@@ -145,5 +145,6 @@ urlpatterns = patterns('',
 
 # Pagination Custom Function to modify LimitedResultPagination
 class StandardResultPagination(LimitOffsetPagination):
-    page_size = 100  # this also sets default_limit to same value
+    PAGE_SIZE = 100  # this also sets default_limit to same value
     max_limit = 1000 # we need to set this, default is None
+    default_limit = 100

--- a/neurovault/apps/statmaps/urls.py
+++ b/neurovault/apps/statmaps/urls.py
@@ -1,3 +1,4 @@
+from rest_framework.pagination import LimitOffsetPagination
 from django.conf.urls import patterns, url
 from django.views.generic import ListView
 from .models import Collection
@@ -141,3 +142,8 @@ urlpatterns = patterns('',
         name='find_similar')
 
 )
+
+# Pagination Custom Function to modify LimitedResultPagination
+class StandardResultPagination(LimitOffsetPagination):
+    page_size = 100  # this also sets default_limit to same value
+    max_limit = 1000 # we need to set this, default is None

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -808,7 +808,7 @@ def find_similar(request,pk):
     
         # We will need lists of image ids, png paths, query id, query path, tags, names, scores
         image_ids = [image.pk for image in images]
-        png_img_paths = [image.thumbnail.url for image in images]
+        png_img_paths = [image.get_thumbnail_url() for image in images]
         tags = [[str(image.map_type)] for image in images]
     
         # The top text will be the collection name, the bottom text the image name

--- a/neurovault/settings.py
+++ b/neurovault/settings.py
@@ -215,6 +215,11 @@ REST_FRAMEWORK = {
     'DEFAULT_MODEL_SERIALIZER_CLASS':
         'rest_framework.serializers.HyperlinkedModelSerializer',
 
+    # LimitOffsetPagination will allow to set a ?limit= and ?offset= 
+    # variable in the URL.
+    'DEFAULT_PAGINATION_CLASS': 
+         'neurovault.apps.statmaps.urls.StandardResultPagination',
+
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [

--- a/neurovault/urls.py
+++ b/neurovault/urls.py
@@ -1,29 +1,30 @@
-from django.conf.urls import patterns, include, url
-from django.conf import settings
-from django.contrib import admin
+from neurovault.apps.statmaps.voxel_query_functions import voxelToRegion, getSynonyms, toAtlas, getAtlasVoxels
+from rest_framework.relations import StringRelatedField, PrimaryKeyRelatedField
 from neurovault.apps.statmaps.models import Image, Collection, StatisticMap,\
     Atlas, NIDMResults, NIDMResultStatisticMap, CognitiveAtlasTask
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.conf.urls.static import static
 from rest_framework.filters import DjangoFilterBackend
+from django.conf.urls import patterns, include, url
+from django.conf.urls.static import static
+from django.conf import settings
+from django.contrib import admin
 from lxml.etree import xmlfile
-from rest_framework.relations import StringRelatedField, PrimaryKeyRelatedField
 admin.autodiscover()
-from django.contrib.auth.models import User, Group
 from rest_framework import viewsets, routers, serializers, mixins, generics
+from neurovault.apps.statmaps.views import get_image,get_collection
 from rest_framework.decorators import detail_route, list_route
+from django.contrib.auth.models import User, Group
+from rest_framework.renderers import JSONRenderer
+from django.http import Http404, HttpResponse
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from taggit.models import Tag
-from django.http import Http404, HttpResponse
-from rest_framework.renderers import JSONRenderer
-from neurovault.apps.statmaps.views import get_image,get_collection
-import re
 import xml.etree.ElementTree as ET
+from taggit.models import Tag
+import cPickle as pickle
 import urllib2
 import os
-import cPickle as pickle
-from neurovault.apps.statmaps.voxel_query_functions import voxelToRegion, getSynonyms, toAtlas, getAtlasVoxels
+import re
+
 
 from django import template
 template.add_to_builtins('django.templatetags.future')


### PR DESCRIPTION
This is a quick fix to add pagination to the API (and fix it's broken-ness!). It was incredibly simple to implement and get working. A few notes:

- The default urls (eg "neurovault.org/api/images") will return 100 results per page, starting at offset 0.
- The user can set the ?limit= argument to return more results, and we set a max_result limit of 1000
- To accomplish this, we have a custom class defined in the [urls.py](https://github.com/vsoch/NeuroVault/blob/fix/api/neurovault/apps/statmaps/urls.py#L147), and we set this to be the default behavior in [settings.py](https://github.com/vsoch/NeuroVault/blob/fix/api/neurovault/settings.py#L219)
- this update is intended to fix #122 and does not improve performance of the API. Reading [here](http://www.dabapps.com/blog/api-performance-profiling-django-rest-framework/) we most definitely want to use cache - I will open a new issue for this.