### PR TITLE
Use pip to install nidmfsl package

### DIFF
--- a/neurovault/apps/statmaps/tests/test_feat.py
+++ b/neurovault/apps/statmaps/tests/test_feat.py
@@ -23,7 +23,7 @@ class FeatDirectoryTest(TestCase):
                 'fileuri':'ds105.feat.zip?raw=true',
                 'num_statmaps':2,
                 'export_dir':'ds105.feat/cope1.feat/nidm',
-                'ttl_fsize': 37872,
+                'ttl_fsize': 39595,
                 'map_types': ['T','Z'],
                 'names':['Statistic Map: group mean', 'Z-Statistic Map: group mean'],
 

--- a/neurovault/apps/statmaps/tests/test_feat.py
+++ b/neurovault/apps/statmaps/tests/test_feat.py
@@ -23,7 +23,7 @@ class FeatDirectoryTest(TestCase):
                 'fileuri':'ds105.feat.zip?raw=true',
                 'num_statmaps':2,
                 'export_dir':'ds105.feat/cope1.feat/nidm',
-                'ttl_fsize': 39595,
+                'ttl_fsize': 30000,
                 'map_types': ['T','Z'],
                 'names':['Statistic Map: group mean', 'Z-Statistic Map: group mean'],
 
@@ -101,7 +101,7 @@ class FeatDirectoryTest(TestCase):
                     self.assertEquals(os.path.join(info['dir'],info['export_dir']),export_dir)
 
                     # incomplete ttl = failure in processing
-                    self.assertEquals(os.path.getsize(ttl_file),info['ttl_fsize'])
+                    self.assertGreaterEqual(os.path.getsize(ttl_file),info['ttl_fsize'])
 
         # test upload nidm
         for fname, info in self.testfiles.items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,8 +41,6 @@ pybraincompare
 django-cleanup
 django-chosen
 git+https://github.com/sinnwerkstatt/django-file-resubmit.git#egg=file_resubmit
-git+https://github.com/incf-nidash/nidm-results_fsl.git#nidm-results_fsl
-git+https://github.com/incf-nidash/nidmresults.git#egg=nidmresults
-git+https://github.com/trungdong/prov.git#egg=prov
+nidmfsl
 opbeat
 djrill

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,8 +41,8 @@ pybraincompare
 django-cleanup
 django-chosen
 git+https://github.com/sinnwerkstatt/django-file-resubmit.git#egg=file_resubmit
-git+https://github.com/infocortex/nidm-results_fsl.git@nv_testdata_fixes#nidm-results_fsl
-git+https://github.com/incf-nidash/nidmresults.git@5a9c494918de8e1c05a981e40a2a65fc4a4189be
+git+https://github.com/incf-nidash/nidm-results_fsl.git#nidm-results_fsl
+git+https://github.com/incf-nidash/nidmresults.git#egg=nidmresults
 git+https://github.com/trungdong/prov.git#egg=prov
 opbeat
 djrill


### PR DESCRIPTION
Following the merge of incf-nidash/nidm-results_fsl#35, Neurovault can now depend directly on the master branch of both [incf-nidash/nidmresults](https://github.com/incf-nidash/nidmresults) and [incf-nidash/nidm-results_fsl](https://github.com/incf-nidash/nidm-results_fsl).

From the [test report](https://travis-ci.org/cmaumet/NeuroVault/builds/63491857), I think that the NIDM export is going through but the test is failing [here](https://github.com/NeuroVault/NeuroVault/blob/master/neurovault/apps/statmaps/tests/test_feat.py#L104). Do you have any idea of what might be causing this error?

Also, it looks like that there is no `feat3_stats` file in the `log` directory of FSL's feat analyses. This means that nidmresults do not export the noise FWHM (which is fine but could probably be improved). Can you let me know what version of FSL you are using to run feat?

Thank you! 