### PR TITLE
Fix JavaScript TypeError while saving metadata in a private collection

### DIFF
--- a/neurovault/apps/statmaps/static/scripts/metadata-common.js
+++ b/neurovault/apps/statmaps/static/scripts/metadata-common.js
@@ -45,7 +45,7 @@
   }
 
   NVMetadata.getCollectionIdFromURL = function (url) {
-    var match = url.match(/collections\/(\d+)/);
+    var match = url.match(/collections\/(\w+)/);
     if (match[1]) {
       return match[1];
     }


### PR DESCRIPTION
A regex match fails while extracting a private collection id after a successful ajax request. Subsequent access to the match result yields the exception: 
~~~
TypeError: Cannot read property '1' of null
~~~
