### PR TITLE
Update script to read in CognitiveAtlas tasks and contrasts with API

### DIFF
--- a/neurovault/apps/statmaps/migrations/0026_populate_cogatlas.py
+++ b/neurovault/apps/statmaps/migrations/0026_populate_cogatlas.py
@@ -1,22 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-
+from neurovault.apps.statmaps.tasks import repopulate_cognitive_atlas
 from django.db import models, migrations
-import json, os
+import os
 dir = os.path.abspath(os.path.dirname(__file__))
 
+
+# COGNITIVE ATLAS
+###########################################################################
 def populate_cogatlas(apps, schema_editor):
     CognitiveAtlasTask = apps.get_model("statmaps", "CognitiveAtlasTask")
     CognitiveAtlasContrast = apps.get_model("statmaps", "CognitiveAtlasContrast")
-    json_content = open(os.path.join(dir, "cognitiveatlas_tasks.json")).read()
-    json_content = json_content.decode("utf-8").replace('\t', '')
-    data = json.loads(json_content)
-    for item in data:
-        task = CognitiveAtlasTask(name=item["name"], cog_atlas_id=item["id"])
-        task.save()
-        for contrast in item["contrasts"]:
-            contrast = CognitiveAtlasContrast(name=contrast["conname"], cog_atlas_id=contrast["conid"], task=task)
-            contrast.save()
+    repopulate_cognitive_atlas(CognitiveAtlasTask,CognitiveAtlasContrast)
 
 class Migration(migrations.Migration):
 

--- a/neurovault/apps/statmaps/tasks.py
+++ b/neurovault/apps/statmaps/tasks.py
@@ -189,6 +189,36 @@ def save_voxelwise_pearson_similarity_resample(pk1, pk2,resample_dim=[4,4,4]):
             raise Exception("You are trying to compare an image with itself!")
 
 
+# COGNITIVE ATLAS
+###########################################################################
+def repopulate_cognitive_atlas(CognitiveAtlasTask=None,CognitiveAtlasContrast=None):
+    if CognitiveAtlasTask==None:
+        from neurovault.apps.statmaps.models import CognitiveAtlasTask
+    if CognitiveAtlasContrast==None:
+        from neurovault.apps.statmaps.models import CognitiveAtlasContrast
+    
+    import json, os
+    from cognitiveatlas.api import get_task
+    tasks = get_task()
+
+    # Update tasks
+    for t in range(0,len(tasks.json)):
+        task = tasks.json[t]
+        print "%s of %s" %(t,len(tasks.json)) 
+        if tasks.json[t]["name"]:
+            task, _ = CognitiveAtlasTask.objects.update_or_create(cog_atlas_id=task["id"],defaults={"name":task["name"]})
+            task.save()
+            if tasks.json[t]["id"]:
+                task_details = get_task(id=tasks.json[t]["id"])
+                if task_details.json[0]["contrasts"]:
+                    print "Found %s contrasts!" %(len(task_details.json[0]["contrasts"]))
+                    for contrast in task_details.json[0]["contrasts"]:
+                        contrast, _ = CognitiveAtlasContrast.objects.update_or_create(cog_atlas_id=contrast["id"], 
+                                                                                      defaults={"name":contrast["contrast_text"],
+                                                                                      "task":task})
+                        contrast.save() 
+
+
 
 # HELPER FUNCTIONS ####################################################################################
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ git+https://github.com/trungdong/prov.git#egg=prov
 opbeat
 djrill
 django-hstore==1.3.5
+cognitiveatlas

--- a/scripts/repopulate_cognitive_atlas_tasks.py
+++ b/scripts/repopulate_cognitive_atlas_tasks.py
@@ -14,7 +14,7 @@ for t in range(0,len(tasks.json)):
     if tasks.json[t]["name"]:
         task, _ = CognitiveAtlasTask.objects.update_or_create(cog_atlas_id=task["id"], defaults={"name":task["name"]})
         task.save()
-        if tasks.json[t]["id"]
+        if tasks.json[t]["id"]:
             task_details = get_task(id=tasks.json[t]["id"])
             if task_details.json[0]["contrasts"]:
                 print "Found %s contrasts!" %(len(task_details.json[0]["contrasts"]))

--- a/scripts/repopulate_cognitive_atlas_tasks.py
+++ b/scripts/repopulate_cognitive_atlas_tasks.py
@@ -1,24 +1,2 @@
-import os
-import json
-from neurovault.apps.statmaps.models import CognitiveAtlasTask, CognitiveAtlasContrast
-
-# not required, will be: pip install cognitiveatlas 
-# https://cogat-python.readthedocs.org
-from cognitiveatlas.api import get_task
-tasks = get_task()
-
-# Update tasks
-for t in range(0,len(tasks.json)):
-    task = tasks.json[t]
-    print "%s of %s" %(t,len(tasks.json)) 
-    if tasks.json[t]["name"]:
-        task, _ = CognitiveAtlasTask.objects.update_or_create(cog_atlas_id=task["id"], defaults={"name":task["name"]})
-        task.save()
-        if tasks.json[t]["id"]:
-            task_details = get_task(id=tasks.json[t]["id"])
-            if task_details.json[0]["contrasts"]:
-                print "Found %s contrasts!" %(len(task_details.json[0]["contrasts"]))
-                for contrast in task_details.json[0]["contrasts"]:
-                   contrast, _ = CognitiveAtlasContrast.objects.update_or_create(cog_atlas_id=contrast["id"], defaults={"name":contrast["contrast_text"], "task":task})
-                   contrast.save() 
-
+from neurovault.apps.statmaps.tasks import repopulate_cognitive_atlas
+repopulate_cognitive_atlas()

--- a/scripts/repopulate_cognitive_atlas_tasks.py
+++ b/scripts/repopulate_cognitive_atlas_tasks.py
@@ -1,16 +1,24 @@
 import os
 import json
-from neurovault.apps.statmaps.models import CognitiveAtlasTask,\
-    CognitiveAtlasContrast
-    
-dir = os.path.abspath(os.path.dirname(__file__))
+from neurovault.apps.statmaps.models import CognitiveAtlasTask, CognitiveAtlasContrast
 
-json_content = open(os.path.join(dir, "../neurovault/apps/statmaps/migrations/cognitiveatlas_tasks.json")).read()
-json_content = json_content.decode("utf-8").replace('\t', '').replace("&#39;", "'")
-data = json.loads(json_content)
-for item in data:
-    task, _ = CognitiveAtlasTask.objects.update_or_create(cog_atlas_id=item["id"], defaults={"name":item["name"]})
-    task.save()
-    for contrast in item["contrasts"]:
-        contrast, _ = CognitiveAtlasContrast.objects.update_or_create(cog_atlas_id=contrast["conid"], defaults={"name":contrast["conname"], "task":task})
-        contrast.save()
+# not required, will be: pip install cognitiveatlas 
+# https://cogat-python.readthedocs.org
+from cognitiveatlas.api import get_task
+tasks = get_task()
+
+# Update tasks
+for t in range(0,len(tasks.json)):
+    task = tasks.json[t]
+    print "%s of %s" %(t,len(tasks.json)) 
+    if tasks.json[t]["name"]:
+        task, _ = CognitiveAtlasTask.objects.update_or_create(cog_atlas_id=task["id"], defaults={"name":task["name"]})
+        task.save()
+        if tasks.json[t]["id"]
+            task_details = get_task(id=tasks.json[t]["id"])
+            if task_details.json[0]["contrasts"]:
+                print "Found %s contrasts!" %(len(task_details.json[0]["contrasts"]))
+                for contrast in task_details.json[0]["contrasts"]:
+                   contrast, _ = CognitiveAtlasContrast.objects.update_or_create(cog_atlas_id=contrast["id"], defaults={"name":contrast["contrast_text"], "task":task})
+                   contrast.save() 
+


### PR DESCRIPTION
This PR changes the Cognitive Atlas import script to obtain tasks and contrasts programatically, using the API directly instead of an exported json. I anticipate this functionality to be very important in the coming weeks as we update many tasks and contrasts within the Cognitive Atlas. While in the future it would be ideal to query the API directly via the site pages, given that the API is still in beta I believe it safer to store tasks and contrasts in the database. Additionally, the contrast field is still free response (and should be until the user can add a contrast and immediately see it live) and I am leaving the original json of the tasks, just in case.

The API (seems to be) up to date with the [current CognitiveAtlas](http://www.cognitiveatlas.org/tasks/) content:

      >>> CognitiveAtlasContrast.objects.all().count()
      1458  
      >>> from neurovault.apps.statmaps.models import CognitiveAtlasTask
      >>> CognitiveAtlasTask.objects.all().count()
      635