### PR TITLE
Fix vanishing handsontable container in big collections

### DIFF
--- a/neurovault/apps/statmaps/static/scripts/metadata-edit.js
+++ b/neurovault/apps/statmaps/static/scripts/metadata-edit.js
@@ -84,12 +84,13 @@
 
   function getDefaultHeight(data) {
     var minHeight = 400,
+      maxHeight = 500,
       rowHeight = 24;
 
     if ((data.length + 1) * rowHeight < minHeight) {
       return minHeight;
     } else {
-      return undefined;
+      return maxHeight;
     }
   }
 

--- a/neurovault/apps/statmaps/templates/statmaps/edit_metadata.html
+++ b/neurovault/apps/statmaps/templates/statmaps/edit_metadata.html
@@ -11,7 +11,7 @@
     }
 
     .hot-wrapper {
-        min-height: 380px;
+        min-height: 400px;
     }
 
     #hot {


### PR DESCRIPTION
This should fix [broken Handsontable](https://github.com/NeuroVault/NeuroVault/pull/314#issuecomment-129096859) for collections bigger than 14-15 images.