### PR TITLE
Make a collection url field read_only in API

### DIFF
--- a/neurovault/urls.py
+++ b/neurovault/urls.py
@@ -218,7 +218,7 @@ class NIDMResultsSerializer(serializers.ModelSerializer):
 
 
 class CollectionSerializer(serializers.ModelSerializer):
-    url = HyperlinkedImageURL(source='get_absolute_url')
+    url = HyperlinkedImageURL(source='get_absolute_url', read_only=True)
     images = ImageSerializer(many=True, source='image_set')
     nidm_results = NIDMResultsSerializer(many=True, source='nidmresults_set')
     contributors = SerializedContributors()


### PR DESCRIPTION
This makes a url field read only and fixes "This field is required." error while creating a new collection.