### PR TITLE
User settings pages with tabs

### DIFF
--- a/neurovault/apps/main/static/css/style.css
+++ b/neurovault/apps/main/static/css/style.css
@@ -21,8 +21,8 @@ body {
 }
 
 #navigation {
-       margin-bottom:0px; 
-       padding-right:10px; 
+       margin-bottom:0px;
+       padding-right:10px;
        padding-left:10px;
        width:1200px;
        border-radius: 6px 6px 0px 0px;
@@ -34,7 +34,7 @@ body {
 }
 
 .navigation-container {
-      padding-left:0px; 
+      padding-left:0px;
       /* background:white; */
       /* margin-bottom: 20px; */
       /* margin-top: 20px; */
@@ -224,4 +224,17 @@ ul.collection_nav li {
     -moz-opacity: 0.9;
     opacity: 0.9;
     filter: alpha(opacity=90);
+}
+
+.settings-tabs {
+    margin-top: 28px;
+    margin-bottom: 20px;
+}
+
+.settings-pane {
+    margin-bottom: 30px;
+}
+
+.settings-pane input[type='submit'] {
+    margin-top: 10px;
 }

--- a/neurovault/apps/main/templates/base.html
+++ b/neurovault/apps/main/templates/base.html
@@ -57,7 +57,7 @@
 	  </li>
 	 <li><a href="{% url 'FAQ' %}">FAQ</a></li>
 	 <li><a href="javascript:void(0)" data-uv-lightbox="classic_widget" data-uv-mode="full" data-uv-primary-color="#cc6d00" data-uv-link-color="#007dbf" data-uv-default-mode="feedback" data-uv-forum-id="210717">Give feedback</a>
-	</li>        
+	</li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
           {% if request.user.is_authenticated %}
@@ -68,8 +68,9 @@
 	  </a>
 	  <ul class="dropdown-menu">
 	      <li><a href="{% url 'my_collections' %}">My collections</a></li>
+          <li role="separator" class="divider"></li>
+          <li><a href="{% url 'edit_user' %}">Settings</a></li>
 	      <li><a href="{% url 'logout' %}">Logout</a></li>
-	      <li><a href="{% url 'edit_user' %}">Edit</a></li>
 	  </ul>
 	  </li>
 	  {% else %}
@@ -89,10 +90,10 @@
 {% block footer %}
 <footer style="text-align:center;padding-top:10px">
       <div class="container navigation-container">
-        <p class="text-muted"> 
+        <p class="text-muted">
             <a href="/api-docs">API</a>  &middot;
             <a href="https://github.com/NeuroVault/NeuroVault">Github </a> &middot;
-            <a href="http://www.cognitiveatlas.org">Cognitive Atlas </a> &middot; 
+            <a href="http://www.cognitiveatlas.org">Cognitive Atlas </a> &middot;
             <a href="http://www.neurosynth.org">NeuroSynth </a></p>
       </div>
 </footer>

--- a/neurovault/apps/users/forms.py
+++ b/neurovault/apps/users/forms.py
@@ -1,7 +1,8 @@
 from django import forms
 from django.contrib.auth.models import User
-from django.contrib.auth.forms import UserCreationForm, UserChangeForm,\
-    PasswordChangeForm
+from django.contrib.auth.forms import UserCreationForm, UserChangeForm
+from django.utils.translation import ugettext_lazy as _
+
 
 class UserCreateForm(UserCreationForm):
     email = forms.EmailField(required=True)
@@ -16,20 +17,35 @@ class UserCreateForm(UserCreationForm):
         if commit:
             user.save()
         return user
-    
-class UserEditForm(UserChangeForm):
+
+
+class UserEditForm(forms.ModelForm):
+    username = forms.RegexField(
+        label=_("Username"), max_length=30, regex=r"^[\w.@+-]+$",
+        help_text=_("Required. 30 characters or fewer. Letters, digits and "
+                    "@/./+/-/_ only."),
+        error_messages={
+            'invalid': _("This value may contain only letters, numbers and "
+                         "@/./+/-/_ characters.")})
+
     email = forms.EmailField(required=True)
 
     class Meta:
         model = User
         fields = ("username", "email")
 
+    def __init__(self, *args, **kwargs):
+        super(UserEditForm, self).__init__(*args, **kwargs)
+        f = self.fields.get('user_permissions', None)
+        if f is not None:
+            f.queryset = f.queryset.select_related('content_type')
+
     def save(self, commit=True):
-        user = super(UserChangeForm, self).save(commit=False)
+        user = super(UserEditForm, self).save(commit=False)
         user.email = self.cleaned_data["email"]
         if commit:
             user.save()
         return user
-    
+
     def clean_password(self):
         return ""

--- a/neurovault/apps/users/templates/_simple_settings_form.html
+++ b/neurovault/apps/users/templates/_simple_settings_form.html
@@ -1,0 +1,11 @@
+{% load crispy_forms_tags %}
+
+<div class="row settings-pane">
+  <div class="col-md-6">
+    <form action="" method="post">
+      {% csrf_token %}
+      {{ form | crispy }}
+      <input class="btn btn-primary" type="submit" value="{{ submit_title }}" />
+    </form>
+  </div>
+</div>

--- a/neurovault/apps/users/templates/base_settings.html
+++ b/neurovault/apps/users/templates/base_settings.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h2>Settings</h2>
+  <ul class="nav nav-tabs settings-tabs">
+    <li {% block profiletab %}{% endblock%} ><a href="{% url 'edit_user' %}">Profile</a></li>
+    <li {% block passwordtab %}{% endblock%}><a href="{% url 'password_change' %}">Change password</a></li>
+  </ul>
+  {% block setting_content %}{% endblock %}
+{% endblock %}

--- a/neurovault/apps/users/templates/registration/edit_profile.html
+++ b/neurovault/apps/users/templates/registration/edit_profile.html
@@ -1,0 +1,7 @@
+{% extends "base_settings.html" %}
+
+{% block profiletab %}class="active"{% endblock%}
+
+{% block setting_content %}
+{% include "_simple_settings_form.html" with form=form submit_title="Update profile" %}
+{% endblock %}

--- a/neurovault/apps/users/templates/registration/password_change_form.html
+++ b/neurovault/apps/users/templates/registration/password_change_form.html
@@ -1,7 +1,7 @@
-{% extends "base.html" %}
-{% block content %}
-<form action="" method="post">{% csrf_token %}
-{{ form.as_p }}
-<input type="submit" value="Submit" />
-</form>
+{% extends "base_settings.html" %}
+
+{% block passwordtab %}class="active"{% endblock%}
+
+{% block setting_content %}
+{% include "_simple_settings_form.html" with form=form submit_title="Update password" %}
 {% endblock %}

--- a/neurovault/apps/users/views.py
+++ b/neurovault/apps/users/views.py
@@ -7,6 +7,7 @@ from .forms import UserEditForm, UserCreateForm
 from django.contrib.auth.decorators import login_required
 from django.template.context import RequestContext
 
+
 def view_profile(request, username=None):
     if not username:
         if not request.user:
@@ -17,8 +18,8 @@ def view_profile(request, username=None):
         user = get_object_or_404(User, username=username)
     return render(request, 'registration/profile.html', {'user': user})
 
-def create_user(request):
 
+def create_user(request):
     if request.method == "POST":
         form = UserCreateForm(request.POST, request.FILES, instance=User())
         if form.is_valid():
@@ -33,10 +34,11 @@ def create_user(request):
                 return HttpResponseRedirect(reverse("my_profile"))
     else:
         form = UserCreateForm(instance=User())
-        
+
     context = {"form": form,
                "request": request}
     return render(request, "registration/edit_user.html", context)
+
 
 @login_required
 def edit_user(request):
@@ -45,10 +47,10 @@ def edit_user(request):
         if edit_form.is_valid():
             edit_form.save()
             return HttpResponseRedirect(reverse("my_profile"))
-    return render_to_response("registration/edit_user.html",
-                             {'form':edit_form},
-                             context_instance=RequestContext(request))
-    
+    return render_to_response("registration/edit_profile.html",
+                              {'form': edit_form},
+                              context_instance=RequestContext(request))
+
 # def login(request):
 #     return render_to_response('home.html', {
 #         'plus_id': getattr(settings, 'SOCIAL_AUTH_GOOGLE_PLUS_KEY', None)


### PR DESCRIPTION
This PR replaces current "edit profile" page with two "settings" pages. Settings are split into tabs. The interface for managing OAuth applications from #365 will go into another tab in settings.

The PR renames a link to edit user profile page to "Settings":
![screen shot 2015-10-31 at 00 39 55](https://cloud.githubusercontent.com/assets/264674/10858716/1ba64e80-7f68-11e5-9a97-b154152ecc60.png)

I left the `edit_user.html` intact because I already have it restyled in another branch (sign-in & sign-up.)
