### PR TITLE
removing ttl select button to fix #369, renaming button to fix #370

### DIFF
--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -372,18 +372,22 @@ def view_nidm_results(request, collection_cid, nidm_name):
     nidm_files = [nidmr.ttl_file.path.encode("utf-8")]
     standard_brain = "/static/images/MNI152.nii.gz"
 
-    # We will remove these scripts
-    remove_resources = ["BOOTSTRAPCSS","ROBOTOFONT"]
+    # We will remove these scripts and a button
+    remove_resources = ["BOOTSTRAPCSS","ROBOTOFONT","NIDMSELECTBUTTON"]
 
     # We will remove these columns
     columns_to_remove = ["statmap_location","statmap",
                          "statmap_type","coordinate_id"]
 
+    # Text for the "Select image" button
+    button_text = "Statistical Map"
+
     html_snippet = generate(nidm_files,
                             base_image=standard_brain,
                             remove_scripts=remove_resources,
                             columns_to_remove=columns_to_remove,
-                            template_choice="embed")
+                            template_choice="embed",
+                            button_text=button_text)
 
     context = {"form": form,"nidm_viewer":html_snippet}
     return render(request, "statmaps/edit_nidm_results.html", context)

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,5 +46,5 @@ djrill
 django-hstore==1.3.5
 cognitiveatlas
 django-datatables-view
-git+git://github.com/vsoch/nidmviewer.git
+git+git://github.com/vsoch/nidmviewer.git@0.1
 https://github.com/benkonrath/django-guardian/archive/django-polymorphic.zip


### PR DESCRIPTION
This quick PR will do the following:

- Remove the "select TTL" file box in the top left, since we are only viewing one.
- Rename the button from "BRAINS" to "Statistical Map"

Note that both of these changes require updating the nidmviewer to its latest version!