### PR TITLE
Update django-cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN pip install django-celery
 RUN pip install scikit-learn
 RUN pip install nilearn
 RUN pip install pybraincompare
-RUN pip install django-cleanup
+RUN pip install django-cleanup==0.4.1
 RUN pip install django-chosen
 RUN pip install 'git+https://github.com/sinnwerkstatt/django-file-resubmit.git#egg=file_resubmit'
 RUN pip install nidmfsl

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ django-celery
 scikit-learn
 nilearn
 pybraincompare
-django-cleanup
+django-cleanup==0.4.1
 django-chosen
 git+https://github.com/sinnwerkstatt/django-file-resubmit.git#egg=file_resubmit
 nidmfsl


### PR DESCRIPTION
This PR bumps the django-cleanup's version to 0.4.1. This should resolve the `ValueError: The '...' attribute has no file associated with it.`

This error apparently stemmed from the fact that django-cleanup [invoked](https://github.com/un1t/django-cleanup/blob/138a68ebd01fd4606461490c6040e496621536cd/django_cleanup/models.py#L84) `FieldFile.delete()` which [purged](https://github.com/django/django/blob/abb8dda6c90a730c783ccd3312aa5d39d1fa470b/django/db/models/fields/files.py#L113) the replacement (new) file off the instance.

In 0.4.1 the issue got fixed by [mocking the model instance](https://github.com/un1t/django-cleanup/commit/b100ddb303c55c36bbdcaf8522a3ba3b3cfdd4d5#diff-919d8e181d370b3b82179ea7f231ea46R22).

