### PR TITLE
Add API endpoint for an authenticated user info

### DIFF
--- a/neurovault/api/serializers.py
+++ b/neurovault/api/serializers.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 from django.forms.utils import ErrorDict, ErrorList
 from django.utils.http import urlquote
+from django.contrib.auth.models import User
 from rest_framework import serializers
 from rest_framework.relations import PrimaryKeyRelatedField, StringRelatedField
 
@@ -55,6 +56,12 @@ class NIDMDescriptionSerializedField(serializers.CharField):
             parent = self.parent.instance.nidm_results.name
             fname = os.path.split(self.parent.instance.file.name)[-1]
             return 'NIDM Results: {0}.zip > {1}'.format(parent, fname)
+
+
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'email', 'first_name', 'last_name')
 
 
 class ImageSerializer(serializers.HyperlinkedModelSerializer):

--- a/neurovault/api/urls.py
+++ b/neurovault/api/urls.py
@@ -1,10 +1,15 @@
+from django.conf.urls import url
+
 from rest_framework import routers
 
-from .views import (ImageViewSet, AtlasViewSet, CollectionViewSet,
-                    NIDMResultsViewSet)
+from .views import (AuthUserView, ImageViewSet, AtlasViewSet,
+                    CollectionViewSet, NIDMResultsViewSet)
 
 router = routers.DefaultRouter()
 router.register(r'images', ImageViewSet)
 router.register(r'atlases', AtlasViewSet)
 router.register(r'collections', CollectionViewSet)
 router.register(r'nidm_results', NIDMResultsViewSet)
+
+api_urls = router.urls + [url(r'^user/?$', AuthUserView.as_view(),
+                          name='api-auth-user')]

--- a/neurovault/api/views.py
+++ b/neurovault/api/views.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 
 from django.http import HttpResponse
 from rest_framework import mixins, permissions, status, viewsets
+from rest_framework.views import APIView
 from rest_framework.decorators import detail_route, list_route
 from rest_framework.filters import DjangoFilterBackend
 from rest_framework.renderers import JSONRenderer
@@ -20,8 +21,8 @@ from neurovault.apps.statmaps.voxel_query_functions import (getAtlasVoxels,
                                                             getSynonyms,
                                                             toAtlas,
                                                             voxelToRegion)
-from .serializers import (AtlasSerializer, CollectionSerializer,
-                          EditableAtlasSerializer,
+from .serializers import (UserSerializer, AtlasSerializer,
+                          CollectionSerializer, EditableAtlasSerializer,
                           EditableNIDMResultsSerializer,
                           EditableStatisticMapSerializer, ImageSerializer,
                           NIDMResultsSerializer)
@@ -62,6 +63,14 @@ class APIHelper:
         return Response(
             {'aaData': zip(data.keys(), data.values())}
         )
+
+
+class AuthUserView(APIView):
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get(self, request):
+        serializer = UserSerializer(request.user, context={'request': request})
+        return Response(serializer.data)
 
 
 class ImageViewSet(mixins.RetrieveModelMixin,

--- a/neurovault/apps/statmaps/tests/test_api.py
+++ b/neurovault/apps/statmaps/tests/test_api.py
@@ -241,6 +241,35 @@ class Test_Atlas_APIs(TestCase):
         self.assertEqual(2, len(response['results']))
 
 
+class TestAuthenticatedUser(APITestCase):
+    def setUp(self):
+        self.user_fields = {
+            'username': 'NeuroGuy',
+            'email': 'neuroguy@example.com',
+            'first_name': 'Neuro',
+            'last_name': 'Guy'
+        }
+        self.user = User.objects.create_user(**self.user_fields)
+        self.user.save()
+
+    def test_unauthenticated_user(self):
+        response = self.client.get('/api/user/')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data, {
+            'detail': 'Authentication credentials were not provided.'
+        })
+
+    def test_authenticated_user(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get('/api/user/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data['id'], int)
+
+        for field in self.user_fields.keys():
+            self.assertEqual(response.data[field], self.user_fields[field])
+
+
 class TestCollection(APITestCase):
     def setUp(self):
         self.user_password = 'apitest'

--- a/neurovault/urls.py
+++ b/neurovault/urls.py
@@ -6,7 +6,7 @@ from django.conf.urls import include, patterns, url
 from django.contrib import admin
 from oauth2_provider import views as oauth_views
 
-from neurovault.api.urls import router
+from neurovault.api.urls import api_urls
 
 admin.autodiscover()
 
@@ -31,7 +31,7 @@ urlpatterns = patterns('',
                        url(r'^accounts/',
                            include('neurovault.apps.users.urls')),
                        url(r'^admin/', include(admin.site.urls)),
-                       url(r'^api/', include(router.urls)),
+                       url(r'^api/', include(api_urls)),
                        url(r'^api-auth/', include(
                            'rest_framework.urls', namespace='rest_framework')),
                        url(r'^o/', include((oauth_urlpatterns,


### PR DESCRIPTION
This adds an `/api/user` endpoint to the API. A request to this endpoint will get information about the currently authenticated user.