### PR TITLE
Urlencode next url on the login page

### DIFF
--- a/neurovault/apps/users/templates/registration/login.html
+++ b/neurovault/apps/users/templates/registration/login.html
@@ -40,10 +40,10 @@
 
 
 
-<a href="{% url 'create_user' %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}">Register new account</a>
+<a href="{% url 'create_user' %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}">Register new account</a>
 <br \>
-<a class="zocial facebook"  href="{% url "social:begin" "facebook" %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}">Login using Facebook</a>
+<a class="zocial facebook"  href="{% url "social:begin" "facebook" %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}">Login using Facebook</a>
 <br \>
-<a class="zocial google"  href="{% url "social:begin" "google-oauth2" %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}">Login using Google</a>
+<a class="zocial google"  href="{% url "social:begin" "google-oauth2" %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}">Login using Google</a>
 
 {% endblock %}


### PR DESCRIPTION
This PR fixes "Error: invalid_request. Missing client_id parameter." during OAuth2 flow for an unauthenticated user.

The reason for the error was in missing urlescape for `next` parameter:
~~~
<a href="/accounts/create/?next=/o/authorize/?response_type=code&amp;client_id=aavalon&amp;redirect_uri=%2Fsignin%2Fauthorized">Register new account</a>
~~~
