### PR TITLE
Redirect to "My collections" on Log in or Sign up

### DIFF
--- a/neurovault/apps/users/views.py
+++ b/neurovault/apps/users/views.py
@@ -42,7 +42,7 @@ def create_user(request):
             if request.POST['next']:
                 return HttpResponseRedirect(request.POST['next'])
             else:
-                return HttpResponseRedirect(reverse("my_profile"))
+                return HttpResponseRedirect(reverse("my_collections"))
     else:
         form = UserCreateForm(instance=User())
 

--- a/neurovault/settings.py
+++ b/neurovault/settings.py
@@ -239,8 +239,8 @@ OAUTH2_PROVIDER = {
     'REQUEST_APPROVAL_PROMPT': 'auto'
 }
 
+LOGIN_REDIRECT_URL = '/my_collections/'
 #LOGIN_URL          = '/login-form/'
-#LOGIN_REDIRECT_URL = '/logged-in/'
 #LOGIN_ERROR_URL    = '/login-error/'
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'


### PR DESCRIPTION
This is a simple enhancement. There could be a different "most common user behaviour". Speaking for myself, I rarely need to edit my profile right after I log in:

![screen shot 2016-01-19 at 22 48 56](https://cloud.githubusercontent.com/assets/264674/12430781/a323c160-bf02-11e5-8117-d4edcfe01845.png)

A better destination for a "bare login" (i.e. without "next" url parameter) is probably "My collections".