### PR TITLE
Flash a message on the profile update

### DIFF
--- a/neurovault/apps/users/templates/registration/edit_profile.html
+++ b/neurovault/apps/users/templates/registration/edit_profile.html
@@ -3,5 +3,8 @@
 {% block profiletab %}class="active"{% endblock%}
 
 {% block setting_content %}
+{% if messages %}
+    {% include "_messages_block.html" with messages=messages %}
+{% endif %}
 {% include "_simple_settings_form.html" with form=form submit_title="Update profile" %}
 {% endblock %}

--- a/neurovault/apps/users/templates/registration/password_change_done.html
+++ b/neurovault/apps/users/templates/registration/password_change_done.html
@@ -1,5 +1,0 @@
-{% extends "base.html" %}
-
-{% block content %}
- Your password has been updated.
-{% endblock %}

--- a/neurovault/apps/users/templates/registration/password_change_form.html
+++ b/neurovault/apps/users/templates/registration/password_change_form.html
@@ -3,5 +3,8 @@
 {% block passwordtab %}class="active"{% endblock%}
 
 {% block setting_content %}
+{% if messages %}
+    {% include "_messages_block.html" with messages=messages %}
+{% endif %}
 {% include "_simple_settings_form.html" with form=form submit_title="Update password" %}
 {% endblock %}

--- a/neurovault/apps/users/urls.py
+++ b/neurovault/apps/users/urls.py
@@ -1,7 +1,8 @@
 from django.conf.urls import patterns, url
 from django.conf import settings
 from django.contrib import admin
-from .views import view_profile, edit_user, create_user
+from .views import (view_profile, edit_user, create_user,
+                    password_change_done)
 from django.contrib.auth.views import login
 from django.contrib.auth import views as auth_views
 from oauth2_provider.views.application import ApplicationList
@@ -26,7 +27,7 @@ urlpatterns = patterns('',
                     auth_views.password_change,
                     name='password_change'),
     url(r'^password/change/done/$',
-                    auth_views.password_change_done,
+                    password_change_done,
                     name='password_change_done'),
     url(r'^password/reset/$',
                     auth_views.password_reset,

--- a/neurovault/apps/users/views.py
+++ b/neurovault/apps/users/views.py
@@ -58,12 +58,21 @@ def edit_user(request):
         if edit_form.is_valid():
             edit_form.save()
             messages.success(request,
-                             'Profile has been successfully updated.')
+                             'Your profile has been successfully updated.')
 
             return HttpResponseRedirect(reverse("edit_user"))
     return render_to_response("registration/edit_profile.html",
                               {'form': edit_form},
                               context_instance=RequestContext(request))
+
+
+@login_required
+def password_change_done(request):
+    messages.success(request,
+                     'Your password has been successfully updated.')
+
+    return HttpResponseRedirect(reverse("password_change"))
+
 
 # def login(request):
 #     return render_to_response('home.html', {

--- a/neurovault/apps/users/views.py
+++ b/neurovault/apps/users/views.py
@@ -57,7 +57,10 @@ def edit_user(request):
     if request.method == "POST":
         if edit_form.is_valid():
             edit_form.save()
-            return HttpResponseRedirect(reverse("my_profile"))
+            messages.success(request,
+                             'Profile has been successfully updated.')
+
+            return HttpResponseRedirect(reverse("edit_user"))
     return render_to_response("registration/edit_profile.html",
                               {'form': edit_form},
                               context_instance=RequestContext(request))


### PR DESCRIPTION
This PR unifies the Settings UI. Presently when a user saves the profile or changes the password in Settings the user gets redirected to a blank profile page or to a rudimentary confirmation page. 

With this PR, the user stays on the same page and gets a confirmation in a flash message*:

![screen shot 2016-01-19 at 23 51 27](https://cloud.githubusercontent.com/assets/264674/12431890/148e0dbe-bf09-11e5-9c7a-3ce1c727fe0b.png)

<hr/>
<sup>* Inspired by GitHub's settings.</sup>