### PR TITLE
Add warnings about missing metadata

### DIFF
--- a/neurovault/api/views.py
+++ b/neurovault/api/views.py
@@ -338,3 +338,4 @@ class TagViewSet(viewsets.ModelViewSet):
         from django.db.models import Count
         data = Tag.objects.annotate(action_count=Count('action'))
         return APIHelper.wrap_for_datatables(data)
+

--- a/neurovault/apps/main/static/css/style.css
+++ b/neurovault/apps/main/static/css/style.css
@@ -256,3 +256,24 @@ ul.collection_nav li {
     width: 40%;
     margin-bottom: 60px;
 }
+
+tr.invalid * {
+    color: #a94442;
+}
+tr.invalid a:hover {
+    color: #a94442;
+}
+tr.invalid td {
+    background-color: #f2dede;
+    color: #a94442;
+}
+div.alert {
+    margin-right: 30px;
+}
+div.alert a {
+    color: #a94442;
+    text-decoration: underline;
+}
+div.alert a:hover {
+    color: #a94442;
+}

--- a/neurovault/apps/statmaps/forms.py
+++ b/neurovault/apps/statmaps/forms.py
@@ -469,7 +469,7 @@ class ImageForm(ModelForm, ImageValidationMixin):
         exclude = []
         widgets = {
             'file': AdminResubmitFileWidget,
-            'hdr_file': AdminResubmitFileWidget,
+            'hdr_file': AdminResubmitFileWidget
         }
 
     def clean(self, **kwargs):
@@ -487,6 +487,8 @@ class StatisticMapForm(ImageForm):
     def clean(self, **kwargs):
         cleaned_data = super(StatisticMapForm, self).clean()
         django_file = cleaned_data.get("file")
+
+        cleaned_data["is_valid"] = True #This will be only saved if the form will validate
 
         if django_file and "file" not in self._errors and "hdr_file" not in self._errors:
             django_file.open()
@@ -524,7 +526,7 @@ class StatisticMapForm(ImageForm):
         fields = ('name', 'collection', 'description', 'map_type', 'modality', 'cognitive_paradigm_cogatlas',
                   'cognitive_contrast_cogatlas', 'analysis_level', 'contrast_definition', 'figure',
                   'file', 'ignore_file_warning', 'hdr_file', 'tags', 'statistic_parameters',
-                  'smoothness_fwhm', 'is_thresholded', 'perc_bad_voxels')
+                  'smoothness_fwhm', 'is_thresholded', 'perc_bad_voxels', 'is_valid')
         widgets = {
             'file': AdminResubmitFileWidget,
             'hdr_file': AdminResubmitFileWidget,
@@ -533,7 +535,8 @@ class StatisticMapForm(ImageForm):
             'perc_bad_voxels': HiddenInput,
             'not_mni': HiddenInput,
             'brain_coverage': HiddenInput,
-            'perc_voxels_outside': HiddenInput
+            'perc_voxels_outside': HiddenInput,
+            'is_valid': HiddenInput
         }
 
 
@@ -832,6 +835,9 @@ class NIDMResultsForm(forms.ModelForm, NIDMResultsValidationMixin):
 
     class Meta:
         model = NIDMResults
+        widgets = {
+            'is_valid': forms.HiddenInput()
+        }
         exclude = []
 
     def __init__(self, *args, **kwargs):

--- a/neurovault/apps/statmaps/migrations/0066_basecollectionitem_is_valid.py
+++ b/neurovault/apps/statmaps/migrations/0066_basecollectionitem_is_valid.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('statmaps', '0065_fix_permissions'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='basecollectionitem',
+            name='is_valid',
+            field=models.BooleanField(default=True),
+            preserve_default=False,
+        )
+    ]

--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -277,7 +277,7 @@ class BaseCollectionItem(PolymorphicModel, models.Model):
     add_date = models.DateTimeField('date published', auto_now_add=True)
     modify_date = models.DateTimeField('date modified', auto_now=True)
     tags = TaggableManager(through=ValueTaggedItem, blank=True)
-    is_valid = models.BooleanField()
+    is_valid = models.BooleanField(default=True)
 
     def __unicode__(self):
         return self.name

--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -277,6 +277,7 @@ class BaseCollectionItem(PolymorphicModel, models.Model):
     add_date = models.DateTimeField('date published', auto_now_add=True)
     modify_date = models.DateTimeField('date modified', auto_now=True)
     tags = TaggableManager(through=ValueTaggedItem, blank=True)
+    is_valid = models.BooleanField()
 
     def __unicode__(self):
         return self.name

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html
@@ -192,6 +192,18 @@ var params = [];
                 {% endif %}
             </div>
          </div>
+
+     {% if messages %}
+         <div class="row">
+            <ul class="messages">
+                {% for message in messages %}
+                <div class="alert alert-dismissible alert-danger">
+                    {{ message }}
+                </div>
+                {% endfor %}
+            </ul>
+         </div>
+            {% endif %}
          <div class="row">
             <div class="col-md-9">
              <form action="upload_folder" enctype="multipart/form-data" method= "POST" name="upload_folder_form">
@@ -257,15 +269,6 @@ var params = [];
 
 <!-- Content-->
 <div class="row">
-        {% if messages %}
-        <ul class="messages">
-            {% for message in messages %}
-            <div class="alert alert-dismissible alert-danger">
-                <button class="close data-dismiss alert" type="button">× {{ message }}</button>
-            </div>
-            {% endfor %}
-        </ul>
-        {% endif %}
 
 <div class="col-md-6" style="margin-top:20px">    
     <div class="papaya" data-params="params" style="width:560px; float:left;"></div>

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html
@@ -5,6 +5,26 @@
 <script src="{% static "scripts/jquery-1.10.2.min.js"%}" type="text/javascript"></script>
 <script src="{% static "scripts/bootstrap.min.js"%}" type="text/javascript"></script>
 <link href="http://netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
+<style>
+tr.invalid * {
+    color: #a94442;
+}
+tr.invalid a:hover {
+    color: #a94442;
+}
+tr.invalid td {
+    background-color: #f2dede;
+    color: #a94442;
+}
+div.alert a {
+    color: #a94442;
+    text-decoration: underline;
+}
+div.alert a:hover {
+    color: #a94442;
+}
+</style>
+
 
 <title>{% block title %}NeuroVault: {{collection.name}}{% endblock %}</title>
 
@@ -198,7 +218,7 @@ var params = [];
             <ul class="messages">
                 {% for message in messages %}
                 <div class="alert alert-dismissible alert-danger">
-                    {{ message }}
+                    {{ message|safe }}
                 </div>
                 {% endfor %}
             </ul>
@@ -285,7 +305,7 @@ var params = [];
         <div class='tab-content'>
                <div id='images' class='tab-pane active'>
                {% if not is_empty or not edit_permission %}
-               <table id="collection-images-datatable" class="table table-condensed table-striped table-hover">
+               <table id="collection-images-datatable" class="compact">
                <thead>
                       <tr>
                           <th>View</th>
@@ -315,7 +335,7 @@ var params = [];
               
               {% if not is_empty %}
               <div id="details" class="tab-pane">
-                  <table id="collection-details-datatable" class="table table-condensed table-striped table-hover">
+                  <table id="collection-details-datatable" class="compact">
                   <thead>
                       <tr>
                           <th>Field</th>
@@ -354,10 +374,18 @@ $(document).ready(function() {
     $('#collection-images-datatable').dataTable({
         "processing": true,
         "serverSide": true,
+        "pagingType": "full",
+        "lengthMenu": [ 7, 10, 25, 50, 75, 100 ],
         "columnDefs": [
     		{ "orderable": false, "targets": 0 }
   		],
         "order": [[ 1, "asc" ]],
+        "createdRow": function( row, data, dataIndex ) {
+              if (data[4] == false) {
+                $(row).removeClass('odd');
+                $(row).addClass('invalid');
+              }
+        },
         {% if collection.private %}
         "ajax": "{% url 'collection_images_json' collection.private_token %}"
         {% else %}

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html
@@ -5,25 +5,6 @@
 <script src="{% static "scripts/jquery-1.10.2.min.js"%}" type="text/javascript"></script>
 <script src="{% static "scripts/bootstrap.min.js"%}" type="text/javascript"></script>
 <link href="http://netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
-<style>
-tr.invalid * {
-    color: #a94442;
-}
-tr.invalid a:hover {
-    color: #a94442;
-}
-tr.invalid td {
-    background-color: #f2dede;
-    color: #a94442;
-}
-div.alert a {
-    color: #a94442;
-    text-decoration: underline;
-}
-div.alert a:hover {
-    color: #a94442;
-}
-</style>
 
 
 <title>{% block title %}NeuroVault: {{collection.name}}{% endblock %}</title>

--- a/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
@@ -50,16 +50,6 @@
         {% endinlinecoffeescript %}
 {% include 'statmaps/_papaya_viewer_head.html.haml' %}
 
-<style>
-div.alert a {
-    color: #a94442;
-    text-decoration: underline;
-}
-div.alert a:hover {
-    color: #a94442;
-}
-</style>
-
 {% endblock %}
 
 {% block content %}

--- a/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
@@ -50,6 +50,16 @@
         {% endinlinecoffeescript %}
 {% include 'statmaps/_papaya_viewer_head.html.haml' %}
 
+<style>
+div.alert a {
+    color: #a94442;
+    text-decoration: underline;
+}
+div.alert a:hover {
+    color: #a94442;
+}
+</style>
+
 {% endblock %}
 
 {% block content %}
@@ -110,7 +120,7 @@
 
         - if warning
             .alert.alert-danger
-                {{ warning }}
+                {{ warning| safe }}
 
         %ul#collection-tabs.nav.nav-tabs
             %li

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -240,7 +240,7 @@ def view_image(request, pk, collection_cid=None):
         elif not image.is_valid:
             context['warning'] = "Warning: This map is missing some mandatory metadata!"
             if user_owns_image:
-                context['warning'] += "Please edit image details to provide the missing information."
+                context['warning'] += " Please <a href='edit'>edit image details</a> to provide the missing information."
         elif image.not_mni:
             context['warning'] = "Warning: This map seems not to be in the MNI space (%.4g%% of meaningful voxels are outside of the brain). "%image.perc_voxels_outside
             context['warning'] += "Please transform the map to MNI space. "
@@ -268,7 +268,7 @@ def view_collection(request, cid):
     if not all(collection.basecollectionitem_set.instance_of(StatisticMap).values_list('is_valid', flat=True)):
         msg = "Some of the images in this collection are missing crucial metadata."
         if owner_or_contrib(request,collection):
-            msg += "Please add the missing information by editing images metadata."
+            msg += " Please add the missing information by <a href='editmetadata'>editing images metadata</a>."
         context["messages"] = [msg]
 
     if not is_empty:
@@ -938,8 +938,8 @@ class JSONResponse(HttpResponse):
 
 
 class ImagesInCollectionJson(BaseDatatableView):
-    columns = ['file.url', 'pk', 'name', 'polymorphic_ctype.name']
-    order_columns = ['','pk', 'name', 'polymorphic_ctype.name']
+    columns = ['file.url', 'pk', 'name', 'polymorphic_ctype.name', 'is_valid']
+    order_columns = ['','pk', 'name', 'polymorphic_ctype.name', '']
 
     def get_initial_queryset(self):
         # return queryset used as base for futher sorting/filtering
@@ -963,6 +963,8 @@ class ImagesInCollectionJson(BaseDatatableView):
                 return ""
         elif column == 'polymorphic_ctype.name':
             return type
+        elif column == 'is_valid':
+            return row.is_valid
         else:
             return super(ImagesInCollectionJson, self).render_column(row, column)
 

--- a/scripts/validate_objects.py
+++ b/scripts/validate_objects.py
@@ -1,0 +1,11 @@
+from django.forms.models import model_to_dict
+
+from neurovault.apps.statmaps.forms import EditStatisticMapForm
+from neurovault.apps.statmaps.models import StatisticMap
+
+count = StatisticMap.objects.count()
+for i, image in enumerate(StatisticMap.objects.all()):
+    print "Fixing StatisticMap %d (%d/%d)"%(image.pk, i+1, count)
+    form = EditStatisticMapForm(model_to_dict(image), instance=image, user=image.collection.owner)
+    image.is_valid = form.is_valid()
+    image.save()


### PR DESCRIPTION
When users upload folders or zip files the do not need to input metadata. However, often they are not even aware that there is anything missing. This PR adds warnings about missing metadata.

![screenshot from 2016-01-27 11-52-04](https://cloud.githubusercontent.com/assets/238759/12626296/ed432b1a-c4ec-11e5-829e-ff7d11bcad79.png)
