### PR TITLE
Enhancement: Adding basic search and cognitive atlas view

### DIFF
--- a/neurovault/apps/main/templates/base.html
+++ b/neurovault/apps/main/templates/base.html
@@ -79,6 +79,11 @@
 	</li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
+
+          <!-- Search Icon -->
+          <li><a href="{% url 'search' %}"><i class="fa fa-search"></i></a></li>
+
+          <!-- User Profile -->
           {% if request.user.is_authenticated %}
 	  <li class="dropdown">
 	  <a href="{% url 'my_profile' %}" class="dropdown-toggle" data-toggle="dropdown">

--- a/neurovault/apps/statmaps/cogat_functions.py
+++ b/neurovault/apps/statmaps/cogat_functions.py
@@ -1,29 +1,52 @@
-from neurovault.apps.statmaps.models import CognitiveAtlasTask, CognitiveAtlasContrast
+from neurovault.apps.statmaps.models import CognitiveAtlasTask, CognitiveAtlasContrast, StatisticMap
 from cognitiveatlas.api import get_task, get_concept
 import numpy as np
 
 # Function to make a node
-def make_node(nid,name,color):
-    return {"nid":str(nid),"name":str(name),"color":color}
+def make_node(nid,name,color,url=None):
+    '''make_node will return a json node for a cognitive atlas task, contrast, concept, or an image. if a url is provided, it will be included
+    :param nid: the node id
+    :param name: the node name
+    :param color: the node color
+    :param url: a url for the node to link to when clicked (be careful giving this to non base nodes)
+    '''
+    if url == None:
+        return {"nid":str(nid),"name":str(name),"color":color}
+    else:
+        return {"nid":str(nid),"name":str(name),"color":color,"url":url}
 
-def get_task_graph(task_id):
+def get_task_graph(task_id,get_images_with_contrasts=False):
     '''get_task_graph will return a tree for a single cognitive atlas tasks defined in NeuroVault
+    :param task_id: the Cognitive Atlas task id
+    :param get_images_with_contrasts: boolean to return images that have contrasts (default False)
     '''
     # Get all contrasts defined for Cognitive Atlas
     task = CognitiveAtlasTask.objects.filter(cog_atlas_id=task_id)[0]
-
     task_node = make_node(task.cog_atlas_id,task.name,"#63506d")
     task_contrasts = CognitiveAtlasContrast.objects.filter(task=task)
     task_concepts = []
+
+    images_with_contrasts = []
     for contrast in task_contrasts:
         try:
             contrast_node = make_node(contrast.cog_atlas_id,contrast.name,"#d89013")
             contrast_concepts = get_concept(contrast_id=contrast.cog_atlas_id)
-            children = []
+            children = [] # concept children of a contrast
             current_names = []
+
+            # Do we have images tagged with the contrast?
+            stat_maps = StatisticMap.objects.filter(cognitive_contrast_cogatlas=contrast)
             for concept in contrast_concepts.json:
-                if concept["name"] not in current_names:
-                    children.append(make_node(concept["id"],concept["name"],"#3c7263"))
+                if concept["name"] not in current_names:                   
+                    concept_node = make_node(concept["id"],concept["name"],"#3c7263")
+
+                    # Image nodes
+                    if len(stat_maps) > 0:
+                        stat_map_nodes = [make_node(i.pk,i.name,"#337ab7","/images/%s" %(i.pk)) for i in stat_maps]
+                        concept_node["children"] = stat_map_nodes
+                        images_with_contrasts = images_with_contrasts + [i.pk for i in stat_maps]
+
+                    children.append(concept_node)
                     current_names.append(concept["name"])
                 contrast_node["children"] = children
             # Only append contrast if it has children
@@ -32,5 +55,9 @@ def get_task_graph(task_id):
         except:
             pass
     task_node["children"] = task_concepts    
-    return task_node
 
+    if get_images_with_contrasts == True:
+        images_with_contrasts = np.unique(images_with_contrasts).tolist()
+        return task_node, images_with_contrasts
+    else:
+        return task_node

--- a/neurovault/apps/statmaps/cogat_functions.py
+++ b/neurovault/apps/statmaps/cogat_functions.py
@@ -1,0 +1,36 @@
+from neurovault.apps.statmaps.models import CognitiveAtlasTask, CognitiveAtlasContrast
+from cognitiveatlas.api import get_task, get_concept
+import numpy as np
+
+# Function to make a node
+def make_node(nid,name,color):
+    return {"nid":str(nid),"name":str(name),"color":color}
+
+def get_task_graph(task_id):
+    '''get_task_graph will return a tree for a single cognitive atlas tasks defined in NeuroVault
+    '''
+    # Get all contrasts defined for Cognitive Atlas
+    task = CognitiveAtlasTask.objects.filter(cog_atlas_id=task_id)[0]
+
+    task_node = make_node(task.cog_atlas_id,task.name,"#63506d")
+    task_contrasts = CognitiveAtlasContrast.objects.filter(task=task)
+    task_concepts = []
+    for contrast in task_contrasts:
+        try:
+            contrast_node = make_node(contrast.cog_atlas_id,contrast.name,"#d89013")
+            contrast_concepts = get_concept(contrast_id=contrast.cog_atlas_id)
+            children = []
+            current_names = []
+            for concept in contrast_concepts.json:
+                if concept["name"] not in current_names:
+                    children.append(make_node(concept["id"],concept["name"],"#3c7263"))
+                    current_names.append(concept["name"])
+                contrast_node["children"] = children
+            # Only append contrast if it has children
+            if len(children) > 0:
+                task_concepts.append(contrast_node)
+        except:
+            pass
+    task_node["children"] = task_concepts    
+    return task_node
+

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
@@ -143,6 +143,14 @@ var params = [];
 
     {% if images %}
     <div id="graph" class="tab-pane">
+        <div id="tree"></div>
+        {% if images_without_contrasts %}
+            <p style="padding-left:20px">You must tag the following images to include them in the tree
+            {% for image_wo_contrast in images_without_contrasts %}
+                <a href="/images/{{ image_wo_contrast.pk }}">{{ image_wo_contrast.name}}</a> -
+            {% endfor %}
+            </p>
+        {% endif %}
     {% include "cogatlas/cognitive_atlas_task_tree.html" %}
     </div><!-- close details tab-->
     {% endif %}

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
@@ -6,6 +6,15 @@
 <script src="{% static "scripts/bootstrap.min.js"%}" type="text/javascript"></script>
 <link href="http://netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
 
+<!--Meta data for Google Search-->
+<meta name="pagetype" content="images">
+<meta name="name" content="{{ task.name }}">
+<meta name="cognitive_paradigm_cogatlas" content="{{ task.name }}">
+<meta name="cognitive_paradigm_cogatlas_id" content="{{ task.cog_atlas_id }}">
+<meta name="thumbnail" content="http://www.cognitiveatlas.org/images/logo-front.png">
+<meta name="database" content="neurovault.org">
+<meta name="url" content ="http://www.cognitiveatlas.org/term/id/{{ task.cog_atlas_id }}">
+
 <title>{% block title %}NeuroVault: {{task.name}}{% endblock %}</title>
 
 <script type="text/javascript">
@@ -145,7 +154,7 @@ var params = [];
     <div id="graph" class="tab-pane">
         <div id="tree"></div>
         {% if images_without_contrasts %}
-            <p style="padding-left:20px">You must tag the following images to include them in the tree
+            <p style="padding-left:20px">The following images must be tagged to be included in the tree
             {% for image_wo_contrast in images_without_contrasts %}
                 <a href="/images/{{ image_wo_contrast.pk }}">{{ image_wo_contrast.name}}</a> -
             {% endfor %}

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
@@ -115,7 +115,7 @@ var params = [];
         <h2>{{ task.name }}</h2>
         <div class="row">
             <div class="col-md-3">
-                <div class="lead"><a href="http://www.cognitiveatls.org/term/id/{{ task.cog_atlas_id }}">Task in Cognitive Atlas</a></div>
+                <div class="lead"><a href="http://www.cognitiveatlas.org/term/id/{{ task.cog_atlas_id }}">Task in Cognitive Atlas</a></div>
                 </div>
             </div>
          </div>

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
@@ -6,7 +6,6 @@
 <script src="{% static "scripts/bootstrap.min.js"%}" type="text/javascript"></script>
 <link href="http://netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
 
-
 <title>{% block title %}NeuroVault: {{task.name}}{% endblock %}</title>
 
 <script type="text/javascript">
@@ -54,16 +53,6 @@ var params = [];
 
 <script type='text/javascript'>
 
- function showLoader() {   
-    document.getElementById('spinny').style.display = 'block';
-    document.getElementById('fade').style.display = 'block';
-  }
-
-  function hideLoader() {
-    document.getElementById('spinny').style.display = 'none';
-    document.getElementById('fade').style.display = 'none';
-  }
-
   // Function to add / remove image from viewer
   function viewimage(mrimage) {
 
@@ -100,10 +89,6 @@ var params = [];
   }
 
 (function() {
-  var uldata;
-
-  uldata = void 0;
-
   $(document).ready(function() {
     $('#show-viewer').click((function(_this) {
       return function() {
@@ -113,55 +98,6 @@ var params = [];
         }, 1);
       };
     })(this));
-    $('#delete_collection').click(function(e) {
-      return confirm("Are you sure you want to delete this collection? This operation cannot be undone!");
-    });
-    $('#upload_archive').click(function(e) {
-      return document.getElementById("id_file").click();
-    });
-    $('#upload_folder').click(function(e) {
-      return document.getElementById("folder_input").click();
-    });
-    $('#id_file').change(function(e) {
-      return document.upload_folder_form.submit();
-    });
-    $('#folder_input').change(function(e) {
-      uldata = e.target.files;
-      return $('#upload_process').modal('show');
-    });
-    $("#upload_process").on("shown.bs.modal", function(e) {
-      var csrftoken, data, files, i, paths, xhr;
-      paths = "";
-      files = uldata;
-      xhr = new XMLHttpRequest();
-      data = new FormData();
-      for (i in files) {
-        if (files[i].name !== void 0 && files[i].webkitRelativePath !== void 0) {
-          if (files[i].name.indexOf(".") !== 0 && files[i].webkitRelativePath.indexOf('.files') === -1) {
-            data.append('paths[]', files[i].webkitRelativePath);
-            data.append('file_input[]', files[i]);
-          }
-        }
-      }
-      
-      csrftoken = $.cookie('csrftoken');
-      xhr.open('POST', "upload_folder", true);
-      xhr.setRequestHeader("X-CSRFToken", csrftoken);
-      xhr.onloadstart = function(e){
-                $('.modal-backdrop').removeClass("modal-backdrop"); 
-                showLoader();
-      };
-      
-      // We need to know when the request finishes.
-      xhr.onload = function (e) {
-      if (xhr.status === 200) {
-            hideLoader();
-            return document.location = '';
-          };
-      }
-      xhr.send(data);
-      //return document.location = "";
-    });
     if (navigator.userAgent.indexOf("Safari") > -1 && navigator.userAgent.indexOf("Chrome") === -1) {
       return $('a[href="pycortex"]').hide();
     }
@@ -194,46 +130,52 @@ var params = [];
 </div>
 
 <!-- Content-->
-<div class="row" style="padding-bottom:20px">
 
-<div class="col-md-6" style="margin-top:20px">    
-    <div class="papaya" data-params="params" style="width:560px; float:left;"></div>
-</div>
-<div class="col-md-6">
+<!-- COLLECTION TABS -->
+<ul id='collection-tabs' class='nav nav-tabs'>
+       <li><a data-toggle='tab' href='#images'>Images</a></li>
+      {% if images %}
+        <li><a data-toggle='tab' href='#graph'>Graph</a></li>
+      {% endif %}
+</ul>
 
-        <!-- COLLECTION TABS -->
-        <ul id='collection-tabs' class='nav nav-tabs'>
-              <li><a data-toggle='tab' href='#images'>Images</a></li>
-              <li><a data-toggle='tab' href='#graph'>Graph</a></li>
-        </ul>
+<div class='tab-content' style="padding-bottom:20px">
 
-        <div class='tab-content' style="padding-bottom:20px">
-               <div id='images' class='tab-pane active'>
-               {% if images %}
-               <table id="collection-images-datatable" class="compact">
-               <thead>
-                      <tr>
-                          <th>View</th>
-                          <th>ID</th>
-                          <th>Name</th>
-                          <th>Type</th>
-                      </tr>
-               </thead>
-               </table>
-               {% else %}
-               <div class="center-text" style="margin-top:60px;">
-                    <div style="font-size:34px;" style="margin-bottom:30px">
-                        No images matching task.
-                    </div>
-                    <br><br>
-              {% endif %} <!-- close if images -->
-              </form>
+    {% if images %}
+    <div id="graph" class="tab-pane">
+    {% include "cogatlas/cognitive_atlas_task_tree.html" %}
+    </div><!-- close details tab-->
+    {% endif %}
 
-              </div><!-- Close images tab-->  
-              
-              <div id="graph" class="tab-pane">
-                {{ cognitive_atlas_tree | safe }}
-              </div><!-- close details tab-->
+<div id='images' class='tab-pane active'>
+
+    <div class="row" style="padding-bottom:20px">
+    <div class="col-md-6" style="margin-top:20px">    
+        <div class="papaya" data-params="params" style="width:560px; float:left;"></div>
+    </div>
+        <div class="col-md-6">
+      
+            {% if images %}
+            <table id="collection-images-datatable" class="compact">
+                <thead>
+                    <tr>
+                        <th>View</th>
+                        <th>ID</th>
+                        <th>Name</th>
+                        <th>Type</th>
+                    </tr>
+                </thead>
+            </table>
+            {% else %}
+            <div class="center-text" style="margin-top:60px;">
+                <div style="font-size:34px;" style="margin-bottom:30px">
+                    No images matching task.
+                </div>
+                <br><br>
+            {% endif %} <!-- close if images -->
+
+            </div><!-- Close images tab-->  
+
          </div><!-- close tab content-->
     </div>
 </div>

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task_tree.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task_tree.html
@@ -193,6 +193,7 @@ function update(source) {
         .attr('y', legendRectSize - legendSpacing)              
         .text(function(d) { return d.name; });                       
 
+
 // Toggle children on click
 function click(d) {
   if (d.children) {

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task_tree.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task_tree.html
@@ -1,0 +1,167 @@
+<script src="https://d3js.org/d3.v3.min.js"></script>
+
+<style>
+
+.node {
+  cursor: pointer;
+}
+
+.node circle {
+  fill: #fff;
+  stroke: steelblue;
+  stroke-width: 1.5px;
+}
+
+.node text {
+  font: 10px sans-serif;
+}
+
+.link {
+  fill: none;
+  stroke: #ccc;
+  stroke-width: 1.5px;
+}
+
+</style>
+
+<script>
+
+var margin = {top: 20, right: 10, bottom: 20, left: 250},
+    width = 960 - margin.right - margin.left,
+    height = 400 - margin.top - margin.bottom;
+    
+var i = 0,
+    duration = 750,
+    root;
+
+var tree = d3.layout.tree()
+    .size([height, width]);
+
+var diagonal = d3.svg.diagonal()
+    .projection(function(d) { return [d.y, d.x]; });
+
+var svg = d3.select("#{{ tree_divid }}").append("svg")
+    .attr("width", width + margin.right + margin.left)
+    .attr("height", height + margin.top + margin.bottom)
+  .append("g")
+    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+
+    root = {{ cognitive_atlas_tree | safe }}
+
+    root.x0 = height / 2;
+    root.y0 = 0;
+
+    function collapse(d) {
+    if (d.children) {
+        d._children = d.children;
+        d._children.forEach(collapse);
+        d.children = null;
+      }
+    }
+
+    root.children.forEach(collapse);
+    update(root);
+
+    d3.select(self.frameElement).style("height", "800px");
+
+function update(source) {
+
+   // Compute the new tree layout.
+   var nodes = tree.nodes(root).reverse(),
+      links = tree.links(nodes);
+
+  // Normalize for fixed-depth.
+  nodes.forEach(function(d) { d.y = d.depth * 180; });
+
+  // Update the nodes
+  var node = svg.selectAll("g.node")
+      .data(nodes, function(d) { return d.id || (d.id = ++i); });
+
+  // Enter any new nodes at the parent's previous position
+  var nodeEnter = node.enter().append("g")
+      .attr("class", "node")
+      .attr("transform", function(d) { return "translate(" + source.y0 + "," + source.x0 + ")"; })
+      .on("click", click);
+
+  nodeEnter.append("circle")
+      .attr("r", 1e-6)
+      .style("fill", function(d) { return d._children ? d.color : "#fff"; });
+
+  nodeEnter.append("text")
+      .attr("x", function(d) { return d.children || d._children ? -10 : 10; })
+      .attr("dy", ".35em")
+      .attr("text-anchor", function(d) { return d.children || d._children ? "end" : "start"; })
+      .text(function(d) { return d.name; })
+      .style("fill-opacity", 1e-6);
+
+  // Transition nodes to their new position
+  var nodeUpdate = node.transition()
+      .duration(duration)
+      .attr("transform", function(d) { return "translate(" + d.y + "," + d.x + ")"; });
+
+  nodeUpdate.select("circle")
+      .attr("r", 4.5)
+      .style("fill", function(d) { return d._children ? "lightsteelblue" : "#fff"; });
+
+  nodeUpdate.select("text")
+      .style("fill-opacity", 1);
+
+  // Transition exiting nodes to the parent's new position
+  var nodeExit = node.exit().transition()
+      .duration(duration)
+      .attr("transform", function(d) { return "translate(" + source.y + "," + source.x + ")"; })
+      .remove();
+
+  nodeExit.select("circle")
+      .attr("r", 1e-6);
+
+  nodeExit.select("text")
+      .style("fill-opacity", 1e-6);
+
+  // Update the links
+  var link = svg.selectAll("path.link")
+      .data(links, function(d) { return d.target.id; });
+
+  // Enter any new links at the parent's previous position
+  link.enter().insert("path", "g")
+      .attr("class", "link")
+      .attr("d", function(d) {
+        var o = {x: source.x0, y: source.y0};
+        return diagonal({source: o, target: o});
+      });
+
+  // Transition links to their new position
+  link.transition()
+      .duration(duration)
+      .attr("d", diagonal);
+
+  // Transition exiting nodes to the parent's new position
+  link.exit().transition()
+      .duration(duration)
+      .attr("d", function(d) {
+        var o = {x: source.x, y: source.y};
+        return diagonal({source: o, target: o});
+      })
+      .remove();
+
+  // Stash the old positions for transition
+  nodes.forEach(function(d) {
+    d.x0 = d.x;
+    d.y0 = d.y;
+  });
+
+
+// Toggle children on click
+function click(d) {
+  if (d.children) {
+    d._children = d.children;
+    d.children = null;
+  } else {
+    d.children = d._children;
+    d._children = null;
+  }
+  update(d);
+}
+}
+</script>

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task_tree.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task_tree.html
@@ -203,6 +203,9 @@ function click(d) {
     d._children = null;
   }
   update(d);
+  if (d.url) {
+    document.location = d.url;
+  }
 }
 }
 </script>

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task_tree.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task_tree.html
@@ -8,7 +8,6 @@
 
 .node circle {
   fill: #fff;
-  stroke: steelblue;
   stroke-width: 1.5px;
 }
 
@@ -22,12 +21,18 @@
   stroke-width: 1.5px;
 }
 
+.legend {
+  font-size: 12px;
+}
+rect {
+  stroke-width: 2;
+}
 </style>
 
 <script>
 
 var margin = {top: 20, right: 10, bottom: 20, left: 250},
-    width = 960 - margin.right - margin.left,
+    width = 1100 - margin.right - margin.left,
     height = 400 - margin.top - margin.bottom;
     
 var i = 0,
@@ -86,7 +91,8 @@ function update(source) {
 
   nodeEnter.append("circle")
       .attr("r", 1e-6)
-      .style("fill", function(d) { return d._children ? d.color : "#fff"; });
+      .style("fill", function(d) { return d._children ? d.color : d.color; })
+      .style("stroke", function(d) { return d._children ? d.color : d.color; });
 
   nodeEnter.append("text")
       .attr("x", function(d) { return d.children || d._children ? -10 : 10; })
@@ -102,7 +108,8 @@ function update(source) {
 
   nodeUpdate.select("circle")
       .attr("r", 4.5)
-      .style("fill", function(d) { return d._children ? "lightsteelblue" : "#fff"; });
+      .style("fill", function(d) { return d._children ? d.color : d.color; })
+      .style("stroke", function(d) { return d._children ? d.color : d.color; });
 
   nodeUpdate.select("text")
       .style("fill-opacity", 1);
@@ -151,6 +158,40 @@ function update(source) {
     d.y0 = d.y;
   });
 
+  // Add legend
+  var legendRectSize = 18;
+  var legendSpacing = 4;
+
+  // task, contrast, concept, image
+  var lookup = [{"color":"#63506d","name":"Task"},
+                {"color":"#d89013","name":"Contrast"},
+                {"color":"#3c7263","name":"Concept"},
+                {"color":"#337ab7","name":"Image"}]
+
+  var legend = svg.selectAll('.legend')
+      .data(lookup)
+      .enter()
+      .append('g')
+      .attr('class', 'legend')
+      .attr('transform', function(d, i) {
+          var lheight = legendRectSize + legendSpacing;
+          var offset =  (lheight * lookup.length / 2) - 50;
+          var horz = -2 * legendRectSize + 800;
+          var vert = i * lheight - offset;
+          return 'translate(' + horz + ',' + vert + ')';
+      });
+
+
+    legend.append('rect')                                     
+        .attr('width', legendRectSize)                        
+        .attr('height', legendRectSize)                       
+        .style('fill', function(d) {return d.color})                                 
+        .style('stroke', function(d) {return d.color});                              
+          
+    legend.append('text')                                     
+        .attr('x', legendRectSize + legendSpacing)              
+        .attr('y', legendRectSize - legendSpacing)              
+        .text(function(d) { return d.name; });                       
 
 // Toggle children on click
 function click(d) {

--- a/neurovault/apps/statmaps/templates/statmaps/_meta_collection.html
+++ b/neurovault/apps/statmaps/templates/statmaps/_meta_collection.html
@@ -1,367 +1,276 @@
 <meta name="pagetype" content="collections">
 <meta name="name" content="{{ collection.name }}">
 <meta name="database" content="neurovault.org">
-
 {% if collection.authors %}
 <meta name="authors" content="{{ collection.authors }}">
 {% endif %}
-
 {% if collection.echo_time %}
 <meta name="echo_time" content="{{ collection.echo_time }}">
 {% endif %}
-
 {% if collection.number_of_rejected_subjects %}
 <meta name="number_related_subjects" content="{{ collection.number_of_rejected_subjects }}">
 {% endif %}
-
 {% if collection.inclusion_exclusion_criteria %}
 <meta name="inclusion_exclusion_criteria" content="{{ collection.inclusion_exclusion_criteria }}">
 {% endif %}
-
 {% if collection.group_comparison %}
 <meta name="group_comparison" content="{{ collection.group_comparison }}">
 {% endif %}
-
 {% if collection.paper_url %}
 <meta name="paper_url" content="{{ collection.paper_url }}">
 {% endif %}
-
 {% if collection.subject_age_max %}
 <meta name="subject_age_max" content="{{ collection.subject_age_max }}">
 {% endif %}
-
 {% if collection.add_date %}
 <meta name="add_date" content="{{ collection.add_date }}">
 {% endif %}
-
 {% if collection.journal_name %}
 <meta name="journal_name" content="{{ collection.journal_name }}">
 {% endif %}
-
 {% if collection.used_intersubject_registration %}
 <meta name="used_intersubject_registration" content="{{ collection.used_intersubject_registration }}">
 {% endif %}
-
 {% if collection.intrasubject_estimation_type %}
 <meta name="intrasubject_estimation_type" content="{{ collection.intrasubject_estimation_type }}">
 {% endif %}
-
 {% if collection.field_of_view %}
 <meta name="field_of_view" content="{{ collection.field_of_view }}">
 {% endif %}
-
 {% if collection.order_of_preprocessing_operations %}
 <meta name="order_of_preprocessing_operations" content="{{ collection.order_of_preprocessing_operations }}">
 {% endif %}
-
 {% if collection.smoothing_type %}
 <meta name="smoothing_type" content="{{ collection.smoothing_type }}">
 {% endif %}
-
 {% if collection.smoothing_fwhm %}
 <meta name="smoothing_fwhm" content="{{ collection.smoothing_fwhm }}">
 {% endif %}
-
 {% if collection.subject_age_min %}
 <meta name="subject_age_min" content="{{ collection.subject_age_min }}">
 {% endif %}
-
 {% if collection.length_of_blocks %}
 <meta name="length_of_blocks" content="{{ collection.length_of_blocks }}">
 {% endif %}
-
 {% if collection.used_orthogonalization %}
 <meta name="used_orthogonalization" content="{{ collection.used_orthogonalization }}">
 {% endif %}
-
 {% if collection.used_b0_unwarping %}
 <meta name="used_b0_unwarping" content="{{ collection.used_b0_unwarping }}">
 {% endif %}
-
 {% if collection.used_temporal_derivatives %}
 <meta name="used_temporal_derivatives" content="{{ collection.used_temporal_derivatives }}">
 {% endif %}
-
 {% if collection.software_package %}
 <meta name="collection.software_package" content="{{ collection.software_package }}">
 {% endif %}
-
 {% if collection.scanner_model %}
 <meta name="collection.scanner_model" content="{{ collection.scanner_model }}">
 {% endif %}
-
 {% if collection.high_pass_filter_method %}
 <meta name="collection.high_pass_filter_method" content="{{ collection.high_pass_filter_method }}">
 {% endif %}
-
 {% if collection.proportion_male_subjects %}
 <meta name="collection.proportion_male_subjects" content="{{ collection.proportion_male_subjects }}">
 {% endif %}
-
 {% if collection.number_of_imaging_runs %}
 <meta name="collection.number_of_imaging_runs" content="{{ collection.number_of_imaging_runs }}">
 {% endif %}
-
 {% if collection.interpolation_method %}
 <meta name="interpolation_method" content="{{ collection.interpolation_method }}">
 {% endif %}
-
 {% if collection.group_repeated_measures_method %}
 <meta name="group_repeated_measures_method" content="{{ collection.group_repeated_measures_method }}">
 {% endif %}
-
 {% if collection.motion_correction_software %}
 <meta name="motion_correction_software" content="{{ collection.motion_correction_software }}">
 {% endif %}
-
 {% if collection.used_motion_regressors %}
 <meta name="used_motion_regressors" content="{{ collection.used_motion_regressors }}">
 {% endif %}
-
 {% if collection.functional_coregistered_to_structural %}
 <meta name="functional_coregistered_to_structural" content="{{ collection.functional_coregistered_to_structural }}">
 {% endif %}
-
 {% if collection.motion_correction_interpolation %}
 <meta name="motion_correction_interpolation" content="{{ collection.motion_correction_interpolation }}">
 {% endif %}
-
 {% if collection.type_of_design %}
 <meta name="type_of_design" content="{{ collection.type_of_design }}">
 {% endif %}
-
 {% if collection.optimization_method %}
 <meta name="optimization_method" content="{{ collection.optimization_method }}">
 {% endif %}
-
 {% if collection.hemodynamic_response_function %}
 <meta name="hemodynamic_response_function" content="{{ collection.hemodynamic_response_function }}">
 {% endif %}
-
 {% if collection.group_model_type %}
 <meta name="group_model_type" content="{{ collection.group_model_type }}">
 {% endif %}
-
 {% if collection.used_slice_timing_correction %}
 <meta name="used_slice_timing_correction" content="{{ collection.used_slice_timing_correction }}">
 {% endif %}
-
 {% if collection.intrasubject_modeling_software %}
 <meta name="intrasubject_modeling_software" content="{{ collection.intrasubject_modeling_software }}">
 {% endif %}
-
 {% if collection.target_template_image %}
 <meta name="target_template_image" content="{{ collection.target_template_image }}">
 {% endif %}
-
 {% if collection.resampled_voxel_size %}
 <meta name="resampled_voxel_size" content="{{ collection.resampled_voxel_size }}">
 {% endif %}
-
 {% if collection.object_image_type %}
 <meta name="object_image_type" content="{{ collection.object_image_type }}">
 {% endif %}
-
 {% if collection.group_description %}
 <meta name="group_description" content="{{ collection.group_description }}">
 {% endif %}
-
 {% if collection.skip_distance %}
 <meta name="skip_distance" content="{{ collection.skip_distance }}">
 {% endif %}
-
 {% if collection.used_dispersion_derivatives %}
 <meta name="used_dispersion_derivatives" content="{{ collection.used_dispersion_derivatives }}">
 {% endif %}
-
 {% if collection.functional_coregistration_method %}
 <meta name="functional_coregistration_method" content="{{ collection.functional_coregistration_method }}">
 {% endif %}
-
 {% if collection.length_of_trials %}
 <meta name="length_of_trials" content="{{ collection.length_of_trials }}">
 {% endif %}
-
 {% if collection.DOI %}
 <meta name="doi" content="{{ collection.DOI }}">
 {% endif %}
-
 {% if collection.number_of_subjects %}
 <meta name="number_of_subjects" content="{{ collection.number_of_subjects }}">
 {% endif %}
-
 {% if collection.used_motion_correction %}
 <meta name="used_motion_correction" content="{{ collection.used_motion_correction }}">
 {% endif %}
-
 {% if collection.pulse_sequence %}
 <meta name="pulse_sequence" content="{{ collection.pulse_sequence }}">
 {% endif %}
-
 {% if collection.used_high_pass_filter %}
 <meta name="used_high_pass_filter" content="{{ collection.used_high_pass_filter }}">
 {% endif %}
-
 {% if collection.full_dataset_url %}
 <meta name="full_dataset_url" content="{{ collection.full_dataset_url }}">
 {% endif %}
-
 {% if collection.orthogonalization_description %}
 <meta name="orthogonalization_description" content="{{ collection.orthogonalization_description }}">
 {% endif %}
-
 {% if collection.acquisition_orientation %}
 <meta name="acquisition_orientation" content="{{ collection.acquisition_orientation }}">
 {% endif %}
-
 {% if collection.order_of_acquisition %}
 <meta name="order_of_acquisition" content="{{ collection.order_of_acquisition }}">
 {% endif %}
-
 {% if collection.group_repeated_measures %}
 <meta name="group_repeated_measures" content="{{ collection.group_repeated_measures }}">
 {% endif %}
-
 {% if collection.motion_correction_reference %}
 <meta name="motion_correction_reference" content="{{ collection.motion_correction_reference }}">
 {% endif %}
-
 {% if collection.group_model_multilevel %}
 <meta name="group_model_multilevel" content="{{ collection.group_model_multilevel }}">
 {% endif %}
-
 {% if collection.number_of_experimental_units %}
 <meta name="number_of_experimental_units" content="{{ collection.number_of_experimental_units }}">
 {% endif %}
-
 {% if collection.handedness %}
 <meta name="handedness" content="{{ collection.handedness }}">
 {% endif %}
-
 {% if collection.coordinate_space %}
 <meta name="coordinate_space" content="{{ collection.coordinate_space }}">
 {% endif %}
-
 {% if collection.transform_similarity_metric %}
 <meta name="transform_similarity_metric" content="{{ collection.transform_similarity_metric }}">
 {% endif %}
-
 {% if collection.repetition_time %}
 <meta name="repetition_time" content="{{ collection.repetition_time }}">
 {% endif %}
-
 {% if collection.slice_thickness %}
 <meta name="slice_thickness" content="{{ collection.slice_thickness }}">
 {% endif %}
-
 {% if collection.length_of_runs %}
 <meta name="length_of_runs" content="{{ collection.length_of_runs }}">
 {% endif %}
-
 {% if collection.software_version %}
 <meta name="software_version" content="{{ collection.software_version }}">
 {% endif %}
-
 {% if collection.autocorrelation_model %}
 <meta name="autocorrelation_model" content="{{ collection.autocorrelation_model }}">
 {% endif %}
-
 {% if collection.b0_unwarping_software %}
 <meta name="b0_unwarping_software" content="{{ collection.b0_unwarping_software }}">
 {% endif %}
-
 {% if collection.intersubject_transformation_type %}
 <meta name="intersubject_transformation_type" content="{{ collection.intersubject_transformation_type }}">
 {% endif %}
-
 {% if collection.quality_control %}
 <meta name="quality_control" content="{{ collection.quality_control }}">
 {% endif %}
-
 {% if collection.used_smoothing %}
 <meta name="used_smoothing" content="{{ collection.used_smoothing }}">
 {% endif %}
-
 {% if collection.matrix_size %}
 <meta name="matrix_size" content="{{ collection.matrix_size }}">
 {% endif %}
-
 {% if collection.optimization %}
 <meta name="optimization" content="{{ collection.optimization }}">
 {% endif %}
-
 {% if collection.modify_date %}
 <meta name="modify_date" content="{{ collection.modify_date }}">
 {% endif %}
-
 {% if collection.group_inference_type %}
 <meta name="group_inference_type" content="{{ collection.group_inference_type }}">
 {% endif %}
-
 {% if collection.subject_age_mean %}
 <meta name="subject_age_mean" content="{{ collection.subject_age_mean }}">
 {% endif %}
-
 {% if collection.used_motion_susceptibiity_correction %}
 <meta name="used_motion_susceptibiity_correction" content="{{ collection.used_motion_susceptibiity_correction }}">
 {% endif %}
-
 {% if collection.intrasubject_model_type %}
 <meta name="intrasubject_model_type" content="{{ collection.intrasubject_model_type }}">
 {% endif %}
-
 {% if collection.used_reaction_time_regressor %}
 <meta name="used_reaction_time_regressor" content="{{ collection.used_reaction_time_regressor }}">
 {% endif %}
-
 {% if collection.group_modeling_software %}
 <meta name="group_modeling_software" content="{{ collection.group_modeling_software }}">
 {% endif %}
-
 {% if collection.parallel_imaging %}
 <meta name="parallel_imaging" content="{{ collection.parallel_imaging }}">
 {% endif %}
-
 {% if collection.intersubject_registration_software %}
 <meta name="intersubject_registration_software" content="{{ collection.intersubject_registration_software }}">
 {% endif %}
-
 {% if collection.doi_add_date %}
 <meta name="doi_add_date" content="{{ collection.doi_add_date }}">
 {% endif %}
-
 {% if collection.nonlinear_transform_type %}
 <meta name="nonlinear_transform_type" content="{{ collection.nonlinear_transform_type }}">
 {% endif %}
-
 {% if collection.description %}
 <meta name="description" content="{{ collection.description }}">
 {% endif %}
-
 {% if collection.field_strength %}
 <meta name="field_strength" content="{{ collection.field_strength }}">
 {% endif %}
-
 {% if collection.group_estimation_type %}
 <meta name="group_estimation_type" content="{{ collection.group_estimation_type }}">
 {% endif %}
-
 {% if collection.target_resolution %}
 <meta name="target_resolution" content="{{ collection.target_resolution }}">
 {% endif %}
-
 {% if collection.slice_timing_correction_software %}
 <meta name="slice_timing_correction_software" content="{{ collection.slice_timing_correction_software }}">
 {% endif %}
-
 {% if collection.scanner_make %}
 <meta name="scanner_make" content="{{ collection.scanner_make }}">
 {% endif %}
-
 {% if collection.flip_angle %}
 <meta name="flip_angle" content="{{ collection.flip_angle }}">
 {% endif %}
-
 {% if collection.motion_correction_metric %}
 <meta name="motion_correction_metric" content="{{ collection.motion_correction_metric }}">
 {% endif %}

--- a/neurovault/apps/statmaps/templates/statmaps/_meta_collection.html
+++ b/neurovault/apps/statmaps/templates/statmaps/_meta_collection.html
@@ -1,0 +1,367 @@
+<meta name="pagetype" content="collections">
+<meta name="name" content="{{ collection.name }}">
+<meta name="database" content="neurovault.org">
+
+{% if collection.authors %}
+<meta name="authors" content="{{ collection.authors }}">
+{% endif %}
+
+{% if collection.echo_time %}
+<meta name="echo_time" content="{{ collection.echo_time }}">
+{% endif %}
+
+{% if collection.number_of_rejected_subjects %}
+<meta name="number_related_subjects" content="{{ collection.number_of_rejected_subjects }}">
+{% endif %}
+
+{% if collection.inclusion_exclusion_criteria %}
+<meta name="inclusion_exclusion_criteria" content="{{ collection.inclusion_exclusion_criteria }}">
+{% endif %}
+
+{% if collection.group_comparison %}
+<meta name="group_comparison" content="{{ collection.group_comparison }}">
+{% endif %}
+
+{% if collection.paper_url %}
+<meta name="paper_url" content="{{ collection.paper_url }}">
+{% endif %}
+
+{% if collection.subject_age_max %}
+<meta name="subject_age_max" content="{{ collection.subject_age_max }}">
+{% endif %}
+
+{% if collection.add_date %}
+<meta name="add_date" content="{{ collection.add_date }}">
+{% endif %}
+
+{% if collection.journal_name %}
+<meta name="journal_name" content="{{ collection.journal_name }}">
+{% endif %}
+
+{% if collection.used_intersubject_registration %}
+<meta name="used_intersubject_registration" content="{{ collection.used_intersubject_registration }}">
+{% endif %}
+
+{% if collection.intrasubject_estimation_type %}
+<meta name="intrasubject_estimation_type" content="{{ collection.intrasubject_estimation_type }}">
+{% endif %}
+
+{% if collection.field_of_view %}
+<meta name="field_of_view" content="{{ collection.field_of_view }}">
+{% endif %}
+
+{% if collection.order_of_preprocessing_operations %}
+<meta name="order_of_preprocessing_operations" content="{{ collection.order_of_preprocessing_operations }}">
+{% endif %}
+
+{% if collection.smoothing_type %}
+<meta name="smoothing_type" content="{{ collection.smoothing_type }}">
+{% endif %}
+
+{% if collection.smoothing_fwhm %}
+<meta name="smoothing_fwhm" content="{{ collection.smoothing_fwhm }}">
+{% endif %}
+
+{% if collection.subject_age_min %}
+<meta name="subject_age_min" content="{{ collection.subject_age_min }}">
+{% endif %}
+
+{% if collection.length_of_blocks %}
+<meta name="length_of_blocks" content="{{ collection.length_of_blocks }}">
+{% endif %}
+
+{% if collection.used_orthogonalization %}
+<meta name="used_orthogonalization" content="{{ collection.used_orthogonalization }}">
+{% endif %}
+
+{% if collection.used_b0_unwarping %}
+<meta name="used_b0_unwarping" content="{{ collection.used_b0_unwarping }}">
+{% endif %}
+
+{% if collection.used_temporal_derivatives %}
+<meta name="used_temporal_derivatives" content="{{ collection.used_temporal_derivatives }}">
+{% endif %}
+
+{% if collection.software_package %}
+<meta name="collection.software_package" content="{{ collection.software_package }}">
+{% endif %}
+
+{% if collection.scanner_model %}
+<meta name="collection.scanner_model" content="{{ collection.scanner_model }}">
+{% endif %}
+
+{% if collection.high_pass_filter_method %}
+<meta name="collection.high_pass_filter_method" content="{{ collection.high_pass_filter_method }}">
+{% endif %}
+
+{% if collection.proportion_male_subjects %}
+<meta name="collection.proportion_male_subjects" content="{{ collection.proportion_male_subjects }}">
+{% endif %}
+
+{% if collection.number_of_imaging_runs %}
+<meta name="collection.number_of_imaging_runs" content="{{ collection.number_of_imaging_runs }}">
+{% endif %}
+
+{% if collection.interpolation_method %}
+<meta name="interpolation_method" content="{{ collection.interpolation_method }}">
+{% endif %}
+
+{% if collection.group_repeated_measures_method %}
+<meta name="group_repeated_measures_method" content="{{ collection.group_repeated_measures_method }}">
+{% endif %}
+
+{% if collection.motion_correction_software %}
+<meta name="motion_correction_software" content="{{ collection.motion_correction_software }}">
+{% endif %}
+
+{% if collection.used_motion_regressors %}
+<meta name="used_motion_regressors" content="{{ collection.used_motion_regressors }}">
+{% endif %}
+
+{% if collection.functional_coregistered_to_structural %}
+<meta name="functional_coregistered_to_structural" content="{{ collection.functional_coregistered_to_structural }}">
+{% endif %}
+
+{% if collection.motion_correction_interpolation %}
+<meta name="motion_correction_interpolation" content="{{ collection.motion_correction_interpolation }}">
+{% endif %}
+
+{% if collection.type_of_design %}
+<meta name="type_of_design" content="{{ collection.type_of_design }}">
+{% endif %}
+
+{% if collection.optimization_method %}
+<meta name="optimization_method" content="{{ collection.optimization_method }}">
+{% endif %}
+
+{% if collection.hemodynamic_response_function %}
+<meta name="hemodynamic_response_function" content="{{ collection.hemodynamic_response_function }}">
+{% endif %}
+
+{% if collection.group_model_type %}
+<meta name="group_model_type" content="{{ collection.group_model_type }}">
+{% endif %}
+
+{% if collection.used_slice_timing_correction %}
+<meta name="used_slice_timing_correction" content="{{ collection.used_slice_timing_correction }}">
+{% endif %}
+
+{% if collection.intrasubject_modeling_software %}
+<meta name="intrasubject_modeling_software" content="{{ collection.intrasubject_modeling_software }}">
+{% endif %}
+
+{% if collection.target_template_image %}
+<meta name="target_template_image" content="{{ collection.target_template_image }}">
+{% endif %}
+
+{% if collection.resampled_voxel_size %}
+<meta name="resampled_voxel_size" content="{{ collection.resampled_voxel_size }}">
+{% endif %}
+
+{% if collection.object_image_type %}
+<meta name="object_image_type" content="{{ collection.object_image_type }}">
+{% endif %}
+
+{% if collection.group_description %}
+<meta name="group_description" content="{{ collection.group_description }}">
+{% endif %}
+
+{% if collection.skip_distance %}
+<meta name="skip_distance" content="{{ collection.skip_distance }}">
+{% endif %}
+
+{% if collection.used_dispersion_derivatives %}
+<meta name="used_dispersion_derivatives" content="{{ collection.used_dispersion_derivatives }}">
+{% endif %}
+
+{% if collection.functional_coregistration_method %}
+<meta name="functional_coregistration_method" content="{{ collection.functional_coregistration_method }}">
+{% endif %}
+
+{% if collection.length_of_trials %}
+<meta name="length_of_trials" content="{{ collection.length_of_trials }}">
+{% endif %}
+
+{% if collection.DOI %}
+<meta name="doi" content="{{ collection.DOI }}">
+{% endif %}
+
+{% if collection.number_of_subjects %}
+<meta name="number_of_subjects" content="{{ collection.number_of_subjects }}">
+{% endif %}
+
+{% if collection.used_motion_correction %}
+<meta name="used_motion_correction" content="{{ collection.used_motion_correction }}">
+{% endif %}
+
+{% if collection.pulse_sequence %}
+<meta name="pulse_sequence" content="{{ collection.pulse_sequence }}">
+{% endif %}
+
+{% if collection.used_high_pass_filter %}
+<meta name="used_high_pass_filter" content="{{ collection.used_high_pass_filter }}">
+{% endif %}
+
+{% if collection.full_dataset_url %}
+<meta name="full_dataset_url" content="{{ collection.full_dataset_url }}">
+{% endif %}
+
+{% if collection.orthogonalization_description %}
+<meta name="orthogonalization_description" content="{{ collection.orthogonalization_description }}">
+{% endif %}
+
+{% if collection.acquisition_orientation %}
+<meta name="acquisition_orientation" content="{{ collection.acquisition_orientation }}">
+{% endif %}
+
+{% if collection.order_of_acquisition %}
+<meta name="order_of_acquisition" content="{{ collection.order_of_acquisition }}">
+{% endif %}
+
+{% if collection.group_repeated_measures %}
+<meta name="group_repeated_measures" content="{{ collection.group_repeated_measures }}">
+{% endif %}
+
+{% if collection.motion_correction_reference %}
+<meta name="motion_correction_reference" content="{{ collection.motion_correction_reference }}">
+{% endif %}
+
+{% if collection.group_model_multilevel %}
+<meta name="group_model_multilevel" content="{{ collection.group_model_multilevel }}">
+{% endif %}
+
+{% if collection.number_of_experimental_units %}
+<meta name="number_of_experimental_units" content="{{ collection.number_of_experimental_units }}">
+{% endif %}
+
+{% if collection.handedness %}
+<meta name="handedness" content="{{ collection.handedness }}">
+{% endif %}
+
+{% if collection.coordinate_space %}
+<meta name="coordinate_space" content="{{ collection.coordinate_space }}">
+{% endif %}
+
+{% if collection.transform_similarity_metric %}
+<meta name="transform_similarity_metric" content="{{ collection.transform_similarity_metric }}">
+{% endif %}
+
+{% if collection.repetition_time %}
+<meta name="repetition_time" content="{{ collection.repetition_time }}">
+{% endif %}
+
+{% if collection.slice_thickness %}
+<meta name="slice_thickness" content="{{ collection.slice_thickness }}">
+{% endif %}
+
+{% if collection.length_of_runs %}
+<meta name="length_of_runs" content="{{ collection.length_of_runs }}">
+{% endif %}
+
+{% if collection.software_version %}
+<meta name="software_version" content="{{ collection.software_version }}">
+{% endif %}
+
+{% if collection.autocorrelation_model %}
+<meta name="autocorrelation_model" content="{{ collection.autocorrelation_model }}">
+{% endif %}
+
+{% if collection.b0_unwarping_software %}
+<meta name="b0_unwarping_software" content="{{ collection.b0_unwarping_software }}">
+{% endif %}
+
+{% if collection.intersubject_transformation_type %}
+<meta name="intersubject_transformation_type" content="{{ collection.intersubject_transformation_type }}">
+{% endif %}
+
+{% if collection.quality_control %}
+<meta name="quality_control" content="{{ collection.quality_control }}">
+{% endif %}
+
+{% if collection.used_smoothing %}
+<meta name="used_smoothing" content="{{ collection.used_smoothing }}">
+{% endif %}
+
+{% if collection.matrix_size %}
+<meta name="matrix_size" content="{{ collection.matrix_size }}">
+{% endif %}
+
+{% if collection.optimization %}
+<meta name="optimization" content="{{ collection.optimization }}">
+{% endif %}
+
+{% if collection.modify_date %}
+<meta name="modify_date" content="{{ collection.modify_date }}">
+{% endif %}
+
+{% if collection.group_inference_type %}
+<meta name="group_inference_type" content="{{ collection.group_inference_type }}">
+{% endif %}
+
+{% if collection.subject_age_mean %}
+<meta name="subject_age_mean" content="{{ collection.subject_age_mean }}">
+{% endif %}
+
+{% if collection.used_motion_susceptibiity_correction %}
+<meta name="used_motion_susceptibiity_correction" content="{{ collection.used_motion_susceptibiity_correction }}">
+{% endif %}
+
+{% if collection.intrasubject_model_type %}
+<meta name="intrasubject_model_type" content="{{ collection.intrasubject_model_type }}">
+{% endif %}
+
+{% if collection.used_reaction_time_regressor %}
+<meta name="used_reaction_time_regressor" content="{{ collection.used_reaction_time_regressor }}">
+{% endif %}
+
+{% if collection.group_modeling_software %}
+<meta name="group_modeling_software" content="{{ collection.group_modeling_software }}">
+{% endif %}
+
+{% if collection.parallel_imaging %}
+<meta name="parallel_imaging" content="{{ collection.parallel_imaging }}">
+{% endif %}
+
+{% if collection.intersubject_registration_software %}
+<meta name="intersubject_registration_software" content="{{ collection.intersubject_registration_software }}">
+{% endif %}
+
+{% if collection.doi_add_date %}
+<meta name="doi_add_date" content="{{ collection.doi_add_date }}">
+{% endif %}
+
+{% if collection.nonlinear_transform_type %}
+<meta name="nonlinear_transform_type" content="{{ collection.nonlinear_transform_type }}">
+{% endif %}
+
+{% if collection.description %}
+<meta name="description" content="{{ collection.description }}">
+{% endif %}
+
+{% if collection.field_strength %}
+<meta name="field_strength" content="{{ collection.field_strength }}">
+{% endif %}
+
+{% if collection.group_estimation_type %}
+<meta name="group_estimation_type" content="{{ collection.group_estimation_type }}">
+{% endif %}
+
+{% if collection.target_resolution %}
+<meta name="target_resolution" content="{{ collection.target_resolution }}">
+{% endif %}
+
+{% if collection.slice_timing_correction_software %}
+<meta name="slice_timing_correction_software" content="{{ collection.slice_timing_correction_software }}">
+{% endif %}
+
+{% if collection.scanner_make %}
+<meta name="scanner_make" content="{{ collection.scanner_make }}">
+{% endif %}
+
+{% if collection.flip_angle %}
+<meta name="flip_angle" content="{{ collection.flip_angle }}">
+{% endif %}
+
+{% if collection.motion_correction_metric %}
+<meta name="motion_correction_metric" content="{{ collection.motion_correction_metric }}">
+{% endif %}

--- a/neurovault/apps/statmaps/templates/statmaps/_meta_image.html
+++ b/neurovault/apps/statmaps/templates/statmaps/_meta_image.html
@@ -1,0 +1,45 @@
+<meta name="pagetype" content="images">
+<meta name="name" content="{{ image.name }}">
+<meta name="thumbnail" content="http://www.neurovault.org{{ image.thumbnail.url }}">
+<meta name="file" content="http://www.neurovault.org{{ image.file.url }}">
+<meta name="add_date" content="{{ image.add_date }}">
+<meta name="brain_coverage" content="{{ image.brain_coverage }}">
+<meta name="map_type" content="{{ image.map_type }}">
+<meta name="modality" content="{{ image.modality }}">
+<meta name="database" content="neurovault.org">
+
+{% if image.smoothness_fwhm %}
+<meta name="smoothness_fwhm" content="{{ image.smoothness_fwhm }}">
+{% endif %}
+
+{% if image.analysis_level %}
+<meta name="analysis_level" content="{{ image.analysis_level }}">
+{% endif %}
+
+{% if image.figure %}
+<meta name="figure" content="{{ image.figure }}">
+{% endif %}
+
+{% if image.not_mni == False %}
+<meta name="mni" content="true">
+{% else %}
+<meta name="mni" content="false">
+{% endif %}
+
+<!-- Cognitive Atlas -->
+{% if image.cognitive_contrast_cogatlas_id %}
+<meta name="cognitive_contrast_cogatlas_id" content="{{ image.cognitive_contrast_cogatlas_id }}">
+{% endif %}
+
+{% if image.cognitive_contrast_cogatlas %}
+<meta name="cognitive_contrast_cogatlas" content="{{ image.cognitive_contrast_cogatlas }}">
+{% endif %}
+
+{% if image.cognitive_paradigm_cogatlas_id %}
+<meta name="cognitive_paradigm_cogatlas_id" content="{{ image.cognitive_paradigm_cogatlas_id }}">
+{% endif %}
+
+{% if image.cognitive_paradigm_cogatlas %}
+<meta name="cognitive_paradigm_cogatlas" content="{{ image.cognitive_paradigm_cogatlas }}">
+{% endif %}
+

--- a/neurovault/apps/statmaps/templates/statmaps/_meta_image.html
+++ b/neurovault/apps/statmaps/templates/statmaps/_meta_image.html
@@ -7,19 +7,15 @@
 <meta name="map_type" content="{{ image.map_type }}">
 <meta name="modality" content="{{ image.modality }}">
 <meta name="database" content="neurovault.org">
-
 {% if image.smoothness_fwhm %}
 <meta name="smoothness_fwhm" content="{{ image.smoothness_fwhm }}">
 {% endif %}
-
 {% if image.analysis_level %}
 <meta name="analysis_level" content="{{ image.analysis_level }}">
 {% endif %}
-
 {% if image.figure %}
 <meta name="figure" content="{{ image.figure }}">
 {% endif %}
-
 {% if image.not_mni == False %}
 <meta name="mni" content="true">
 {% else %}
@@ -30,16 +26,12 @@
 {% if image.cognitive_contrast_cogatlas_id %}
 <meta name="cognitive_contrast_cogatlas_id" content="{{ image.cognitive_contrast_cogatlas_id }}">
 {% endif %}
-
 {% if image.cognitive_contrast_cogatlas %}
 <meta name="cognitive_contrast_cogatlas" content="{{ image.cognitive_contrast_cogatlas }}">
 {% endif %}
-
 {% if image.cognitive_paradigm_cogatlas_id %}
 <meta name="cognitive_paradigm_cogatlas_id" content="{{ image.cognitive_paradigm_cogatlas_id }}">
 {% endif %}
-
 {% if image.cognitive_paradigm_cogatlas %}
 <meta name="cognitive_paradigm_cogatlas" content="{{ image.cognitive_paradigm_cogatlas }}">
 {% endif %}
-

--- a/neurovault/apps/statmaps/templates/statmaps/cognitive_atlas_task.html
+++ b/neurovault/apps/statmaps/templates/statmaps/cognitive_atlas_task.html
@@ -1,0 +1,273 @@
+{% extends "base.html" %}
+{% load static from staticfiles %}
+{% block head %}
+<script type="text/javascript" src="{% static "scripts/papaya.js"%}"/>
+<script src="{% static "scripts/jquery-1.10.2.min.js"%}" type="text/javascript"></script>
+<script src="{% static "scripts/bootstrap.min.js"%}" type="text/javascript"></script>
+<link href="http://netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
+
+
+<title>{% block title %}NeuroVault: {{task.name}}{% endblock %}</title>
+
+<script type="text/javascript">
+
+var params = [];
+     
+{% if first_image %}
+   var tmpname = "{{ first_image.file.url }}".replace(/^.*[\\\/]/, '')
+    {% if first_image.map_type == 'Pa' or first_image.polymorphic_ctype.model == 'atlas' %}
+        params["images"] = ["{% static "images/MNI152.nii.gz"%}","{{ first_image.file.url|urlencode }}".replace(" ","")];
+        params[tmpname] = {"parametric": true,  "lut":"Spectrum", "alpha":"0.75", minPercent: 0.0, maxPercent: 1.0};
+    {% elif first_image.map_type == 'R' %}
+        params["images"] = ["{% static "images/MNI152.nii.gz"%}","{{ first_image.file.url|urlencode }}".replace(" ","")];
+        params[tmpname] = {"parametric": true,  "lut":"Overlay (Negatives)", "alpha":"0.75", minPercent: 0.0, maxPercent: 1.0};
+    {% elif first_image.map_type == 'A' %}
+        params["images"] = ["{{ first_image.file.url|urlencode }}".replace(" ","")];
+    {% else %}
+        params["images"] = ["{% static "images/MNI152.nii.gz"%}","{{ first_image.file.url|urlencode }}".replace(" ","")];
+        params[tmpname] = {"parametric": true,  "min":0, "lut":"OrRd", "negative_lut":"PuBu", "alpha":"0.75", "symmetric":true};
+        params["{% static "images/MNI152.nii.gz"%}"] = {"parametric": true,  "min":0, "lut":"OrRd", "negative_lut":"PuBu", "alpha":"0.75", "symmetric":true};
+    {% endif %}
+{% else %}
+   params["images"] = ["{% static "images/MNI152.nii.gz"%}"];
+{% endif %}
+   params["worldSpace"] = true;
+   params["expandable"] = true;
+   params["combineParametric"] = true;
+   params["showControls"] = false;
+   params["smoothDisplay"] = false;
+   params["luts"] = [{"name":"PuBu", "data":[[0,1,0.968627,0.984314],[0.125,0.92549,0.905882,0.94902],[0.25,0.815686,0.819608,0.901961],[0.375,0.65098,0.741176,0.858824],[0.5,0.454902,0.662745,0.811765],[0.625,0.211765,0.564706,0.752941],[0.75,0.0196078,0.439216,0.690196],[0.875,0.0156863,0.352941,0.552941],[1,0.00784314,0.219608,0.345098]]},
+   {"name":"OrRd", "data":[[0,1,0.968627,0.92549],[0.125,0.996078,0.909804,0.784314],[0.25,0.992157,0.831373,0.619608],[0.375,0.992157,0.733333,0.517647],[0.5,0.988235,0.552941,0.34902],[0.625,0.937255,0.396078,0.282353],[0.75,0.843137,0.188235,0.121569],[0.875,0.701961,0,0],[1,0.498039,0,0]]}];
+
+</script>
+
+<!-- Fix for dropdown menus -->
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+<script src="{% static "scripts/jquery.cookie.js"%}" type="text/javascript"></script>
+<script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+<script src="//cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js" type="text/javascript"></script>
+<script src="//cdn.datatables.net/plug-ins/1.10.7/integration/bootstrap/3/dataTables.bootstrap.js" type="text/javascript"></script>
+<link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+<link rel="stylesheet" href="{% static "css/style.css" %}" />
+<link rel="stylesheet" type="text/css" href="/static/css/papaya.css" />
+
+
+<script type='text/javascript'>
+
+ function showLoader() {   
+    document.getElementById('spinny').style.display = 'block';
+    document.getElementById('fade').style.display = 'block';
+  }
+
+  function hideLoader() {
+    document.getElementById('spinny').style.display = 'none';
+    document.getElementById('fade').style.display = 'none';
+  }
+
+  // Function to add / remove image from viewer
+  function viewimage(mrimage) {
+
+     var params = []
+     // Reset viewer and load new images
+     $(".viewimage").removeClass("active")
+
+      var tmpname = $(mrimage).attr("filename").replace(/^.*[\\\/]/, '')
+
+      if ($(mrimage).attr("type") == "atlas" || $(mrimage).attr("type") == "parcellation") {
+        params["images"] = ["{% static "images/MNI152.nii.gz"%}",$(mrimage).attr("filename")];
+      	params[tmpname] = {"parametric": true,  "lut":"Spectrum", "alpha":"0.75",  minPercent: 0.0, maxPercent: 1.0};
+      } else if ($(mrimage).attr("type") == "ROI/mask") {
+        params["images"] = ["{% static "images/MNI152.nii.gz"%}",$(mrimage).attr("filename")];
+        params[tmpname] = {"parametric": true,  "lut":"Overlay (Negatives)", "alpha":"0.75",  minPercent: 0.0, maxPercent: 1.0};
+      } else if ($(mrimage).attr("type") == "anatomical") {
+        params["images"] = [$(mrimage).attr("filename")];
+      } else {
+        params["images"] = ["{% static "images/MNI152.nii.gz"%}",$(mrimage).attr("filename")];
+      	params[tmpname] = {"parametric": true,  "min":0, "lut":"OrRd", "negative_lut":"PuBu", "alpha":"0.75", "symmetric":true};
+      }
+
+      params["worldSpace"] = true;
+      params["expandable"] = true;
+      params["combineParametric"] = true;
+      params["showControls"] = false;
+      params["smoothDisplay"] = false;
+      params["luts"] = [{"name":"PuBu", "data":[[0,1,0.968627,0.984314],[0.125,0.92549,0.905882,0.94902],[0.25,0.815686,0.819608,0.901961],[0.375,0.65098,0.741176,0.858824],[0.5,0.454902,0.662745,0.811765],[0.625,0.211765,0.564706,0.752941],[0.75,0.0196078,0.439216,0.690196],[0.875,0.0156863,0.352941,0.552941],[1,0.00784314,0.219608,0.345098]]},
+      {"name":"OrRd", "data":[[0,1,0.968627,0.92549],[0.125,0.996078,0.909804,0.784314],[0.25,0.992157,0.831373,0.619608],[0.375,0.992157,0.733333,0.517647],[0.5,0.988235,0.552941,0.34902],[0.625,0.937255,0.396078,0.282353],[0.75,0.843137,0.188235,0.121569],[0.875,0.701961,0,0],[1,0.498039,0,0]]}];
+
+      papaya.Container.resetViewer(0, params);  // specify new ones
+      $(mrimage).addClass("active")
+  
+  }
+
+(function() {
+  var uldata;
+
+  uldata = void 0;
+
+  $(document).ready(function() {
+    $('#show-viewer').click((function(_this) {
+      return function() {
+        window.viewer.paint();
+        return setTimeout(function() {
+          return window.viewer.paint();
+        }, 1);
+      };
+    })(this));
+    $('#delete_collection').click(function(e) {
+      return confirm("Are you sure you want to delete this collection? This operation cannot be undone!");
+    });
+    $('#upload_archive').click(function(e) {
+      return document.getElementById("id_file").click();
+    });
+    $('#upload_folder').click(function(e) {
+      return document.getElementById("folder_input").click();
+    });
+    $('#id_file').change(function(e) {
+      return document.upload_folder_form.submit();
+    });
+    $('#folder_input').change(function(e) {
+      uldata = e.target.files;
+      return $('#upload_process').modal('show');
+    });
+    $("#upload_process").on("shown.bs.modal", function(e) {
+      var csrftoken, data, files, i, paths, xhr;
+      paths = "";
+      files = uldata;
+      xhr = new XMLHttpRequest();
+      data = new FormData();
+      for (i in files) {
+        if (files[i].name !== void 0 && files[i].webkitRelativePath !== void 0) {
+          if (files[i].name.indexOf(".") !== 0 && files[i].webkitRelativePath.indexOf('.files') === -1) {
+            data.append('paths[]', files[i].webkitRelativePath);
+            data.append('file_input[]', files[i]);
+          }
+        }
+      }
+      
+      csrftoken = $.cookie('csrftoken');
+      xhr.open('POST', "upload_folder", true);
+      xhr.setRequestHeader("X-CSRFToken", csrftoken);
+      xhr.onloadstart = function(e){
+                $('.modal-backdrop').removeClass("modal-backdrop"); 
+                showLoader();
+      };
+      
+      // We need to know when the request finishes.
+      xhr.onload = function (e) {
+      if (xhr.status === 200) {
+            hideLoader();
+            return document.location = '';
+          };
+      }
+      xhr.send(data);
+      //return document.location = "";
+    });
+    if (navigator.userAgent.indexOf("Safari") > -1 && navigator.userAgent.indexOf("Chrome") === -1) {
+      return $('a[href="pycortex"]').hide();
+    }
+  });
+}).call(this);
+
+</script>
+{% endblock %}
+
+{% block content %}
+<div class="fade"></div>
+
+<!-- Meta data and header row-->
+<div class="row">
+        <h2>{{ task.name }}</h2>
+        <div class="row">
+            <div class="col-md-3">
+                <div class="lead"><a href="http://www.cognitiveatls.org/term/id/{{ task.cog_atlas_id }}">Task in Cognitive Atlas</a></div>
+                </div>
+            </div>
+         </div>
+
+         <div class="row">
+            <div class="col-md-9">
+
+            </div>
+         </div>
+</div>
+<div class="row">
+</div>
+
+<!-- Content-->
+<div class="row" style="padding-bottom:20px">
+
+<div class="col-md-6" style="margin-top:20px">    
+    <div class="papaya" data-params="params" style="width:560px; float:left;"></div>
+</div>
+<div class="col-md-6">
+
+        <!-- COLLECTION TABS -->
+        <ul id='collection-tabs' class='nav nav-tabs'>
+              <li><a data-toggle='tab' href='#images'>Images</a></li>
+              <li><a data-toggle='tab' href='#graph'>Graph</a></li>
+        </ul>
+
+        <div class='tab-content' style="padding-bottom:20px">
+               <div id='images' class='tab-pane active'>
+               {% if images %}
+               <table id="collection-images-datatable" class="compact">
+               <thead>
+                      <tr>
+                          <th>View</th>
+                          <th>ID</th>
+                          <th>Name</th>
+                          <th>Type</th>
+                      </tr>
+               </thead>
+               </table>
+               {% else %}
+               <div class="center-text" style="margin-top:60px;">
+                    <div style="font-size:34px;" style="margin-bottom:30px">
+                        No images matching task.
+                    </div>
+                    <br><br>
+              {% endif %} <!-- close if images -->
+              </form>
+
+              </div><!-- Close images tab-->  
+              
+              <div id="graph" class="tab-pane">
+                {{ cognitive_atlas_tree | safe }}
+              </div><!-- close details tab-->
+         </div><!-- close tab content-->
+    </div>
+</div>
+</div>
+
+<script>
+{% if images %}
+$(document).ready(function() {
+    $('#collection-images-datatable').dataTable({
+        "processing": true,
+        "serverSide": true,
+        "pagingType": "full",
+        "lengthMenu": [ 7, 10, 25, 50, 75, 100 ],
+        "columnDefs": [
+    		{ "orderable": false, "targets": 0 }
+  		],
+        "order": [[ 1, "asc" ]],
+        "createdRow": function( row, data, dataIndex ) {
+              if (data[4] == false) {
+                $(row).removeClass('odd');
+                $(row).addClass('invalid');
+              }
+        },
+        "ajax": "{% url 'task_images_json' task.cog_atlas_id %}",
+        "initComplete": function(settings, json) {
+    		var collection_images = $(".viewimage")
+        	$(collection_images[0]).addClass("active")
+  		}
+    });
+} );
+{% endif %}
+</script>
+
+{% comment %}
+<a href="http://www.cognitiveatlas.org/term/id/{{task.cog_atlas_id}}">{{task.name}}</a> in the Cognitive Atlas
+{% endcomment %}
+{% endblock %}

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html
@@ -7,7 +7,7 @@
 <link href="http://netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
 
 <!-- Meta tags for PageMap: Google Search-->
-{% include _meta_collection.html %}
+{% include "statmaps/_meta_collection.html" %}
 
 <title>{% block title %}NeuroVault: {{collection.name}}{% endblock %}</title>
 

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html
@@ -6,6 +6,8 @@
 <script src="{% static "scripts/bootstrap.min.js"%}" type="text/javascript"></script>
 <link href="http://netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
 
+<!-- Meta tags for PageMap: Google Search-->
+{% include _meta_collection.html %}
 
 <title>{% block title %}NeuroVault: {{collection.name}}{% endblock %}</title>
 

--- a/neurovault/apps/statmaps/templates/statmaps/search.html
+++ b/neurovault/apps/statmaps/templates/statmaps/search.html
@@ -2,9 +2,9 @@
 {% load static from staticfiles %}
 {% block head %}
 <script src="{% static "scripts/jquery-1.10.2.min.js"%}" type="text/javascript"></script>
-<script src="{% static "scripts/bootstrap.min.js"%}" type="text/javascript"></script>
 <script src="{% static "scripts/select2.min.js"%}" type="text/javascript"></script>
 <link href="{% static "css/select2.min.css"%}" rel="stylesheet"></script>
+<script src="{% static "scripts/bootstrap.min.js"%}" type="text/javascript"></script>
 <link href="http://netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
 <title>{% block title %}NeuroVault: Search{% endblock %}</title>
 
@@ -97,30 +97,5 @@ margin-top: 0 !important;
       $('#cogatlas').select2();
    });
 </script> 
-
-<!--
-<script type="text/javascript">// <![CDATA[
-      $("#searchterm").keyup(function(e){
-        var q = $("#searchterm").val();
-        $.getJSON("{% url 'collection_images_json' 1 %}",
-        {
-          q: q,
-          action: "query",
-          list: "search",
-          format: "json"
-        },
-        function(data) {
-          console.log(data);
-          $("#results").empty();
-          $("#results").append("Results for <b>" + q + "</b>");
-          $.each(data.data, function(i,item){
-            console.log(item);
-            //Would need to parse this into something prettier
-            $("#results").append("<div>item</div>");
-          });
-        });
-      });
-//]]</script>
--->
 
 {% endblock %}

--- a/neurovault/apps/statmaps/templates/statmaps/search.html
+++ b/neurovault/apps/statmaps/templates/statmaps/search.html
@@ -34,7 +34,17 @@ margin-top: 0 !important;
 {% block content %}
 <div class="fade"></div>
 
-<!-- Meta data and header row-->
+{% if message %}
+<div class="row">
+    <ul class="messages">
+    <div class="alert alert-dismissible alert-danger">
+    {{ message|safe }}
+    </div>
+    </ul>
+</div>
+{% endif %}
+
+<!-- Search with two columns -->
 <div class="row" style="padding-bottom:30px">
         <h2>Search</h2>
         <div class="row">
@@ -62,13 +72,12 @@ margin-top: 0 !important;
             </div>
 
             <!-- Cognitive Atlas Task Search Column -->
-            <div class="col-md-4" style="padding-top:7px">
+            <div class="col-md-4" style="padding-top:45px">
                 <form action="{% url 'view_task' %}" method="post">
                 {% csrf_token %}
                     <div class="form-group">
-                        <h4>Search by Cognitive Atlas Task:</h4>
                             <select class="form-control" id="cogatlas" name="cogatlas">
-                                <option>--</option>
+                                <option>Search by Cognitive Atlas Task</option>
                                     {% for task in cogatlas_task %}
                                     <option value="{{ task.cog_atlas_id }}">{{ task.name }}</option>
                                     {% endfor %}

--- a/neurovault/apps/statmaps/templates/statmaps/search.html
+++ b/neurovault/apps/statmaps/templates/statmaps/search.html
@@ -1,0 +1,117 @@
+{% extends "base.html" %}
+{% load static from staticfiles %}
+{% block head %}
+<script src="{% static "scripts/jquery-1.10.2.min.js"%}" type="text/javascript"></script>
+<script src="{% static "scripts/bootstrap.min.js"%}" type="text/javascript"></script>
+<script src="{% static "scripts/select2.min.js"%}" type="text/javascript"></script>
+<link href="{% static "css/select2.min.css"%}" rel="stylesheet"></script>
+<link href="http://netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
+<title>{% block title %}NeuroVault: Search{% endblock %}</title>
+
+<style>
+/* Google Style has bug so it's squished */
+.cse .gsc-search-button input.gsc-search-button-v2,
+input.gsc-search-button-v2 {
+width: 28px !important;
+height: 26px !important;
+padding: 4px !important;
+min-width: 13px !important;
+margin-top: 0 !important;
+}
+}
+.gsib_a {
+  padding: 0px !important;
+}
+.gsib_a input {
+  background: none !important;
+}
+.gsc-selected-option-container {
+  min-width: 100px !important;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="fade"></div>
+
+<!-- Meta data and header row-->
+<div class="row" style="padding-bottom:30px">
+        <h2>Search</h2>
+        <div class="row">
+            <div class="col-md-3">
+            </div>
+         </div>
+
+         <div class="row">
+
+            <!-- Google Search Column-->
+            <div class="col-md-8" style="padding-top:30px;padding-bottom-20px;">
+		<script>
+		  (function() {
+		    var cx = '010503388974132107851:0z1x3cffi3u';
+		    var gcse = document.createElement('script');
+		    gcse.type = 'text/javascript';
+		    gcse.async = true;
+		    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
+			'//cse.google.com/cse.js?cx=' + cx;
+		    var s = document.getElementsByTagName('script')[0];
+		    s.parentNode.insertBefore(gcse, s);
+		  })();
+		</script>
+		<gcse:search></gcse:search>
+            </div>
+
+            <!-- Cognitive Atlas Task Search Column -->
+            <div class="col-md-4" style="padding-top:7px">
+                <form action="{% url 'view_task' %}" method="post">
+                {% csrf_token %}
+                    <div class="form-group">
+                        <h4>Search by Cognitive Atlas Task:</h4>
+                            <select class="form-control" id="cogatlas" name="cogatlas">
+                                <option>--</option>
+                                    {% for task in cogatlas_task %}
+                                    <option value="{{ task.cog_atlas_id }}">{{ task.name }}</option>
+                                    {% endfor %}
+                            </select>
+                    </div>
+                    <input type="submit" class="btn btn-default btn-sm" value="Go">
+                </form>
+            </div>
+         </div>
+
+</div>
+<div class="row">
+</div>
+
+<script type="text/javascript">
+   $(document).ready(function(){
+      $('#cogatlas').select2();
+   });
+</script> 
+
+<!--
+<script type="text/javascript">// <![CDATA[
+      $("#searchterm").keyup(function(e){
+        var q = $("#searchterm").val();
+        $.getJSON("{% url 'collection_images_json' 1 %}",
+        {
+          q: q,
+          action: "query",
+          list: "search",
+          format: "json"
+        },
+        function(data) {
+          console.log(data);
+          $("#results").empty();
+          $("#results").append("Results for <b>" + q + "</b>");
+          $.each(data.data, function(i,item){
+            console.log(item);
+            //Would need to parse this into something prettier
+            $("#results").append("<div>item</div>");
+          });
+        });
+      });
+//]]</script>
+-->
+
+{% endblock %}

--- a/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
@@ -4,7 +4,7 @@
 {% block includes %}
 <title>{% block title %}NeuroVault: {{image.name}}{% endblock %}</title>
 <script type="text/javascript" src="{% static "scripts/papaya.js"%}"/>
-{% include _meta_image.html %}
+{% include "statmaps/_meta_image.html" %}
 {% endblock %}
 {% block head %}
     :javascript

--- a/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
@@ -4,6 +4,7 @@
 {% block includes %}
 <title>{% block title %}NeuroVault: {{image.name}}{% endblock %}</title>
 <script type="text/javascript" src="{% static "scripts/papaya.js"%}"/>
+{% include _meta_image.html %}
 {% endblock %}
 {% block head %}
     :javascript

--- a/neurovault/apps/statmaps/urls.py
+++ b/neurovault/apps/statmaps/urls.py
@@ -7,14 +7,15 @@ from rest_framework.pagination import LimitOffsetPagination
 from neurovault import settings
 from neurovault.apps.statmaps.models import KeyValueTag
 from neurovault.apps.statmaps.views import ImagesInCollectionJson,\
-    PublicCollectionsJson, MyCollectionsJson, AtlasesAndParcellationsJson
+    PublicCollectionsJson, MyCollectionsJson, AtlasesAndParcellationsJson, \
+    ImagesByTaskJson
 from .views import edit_collection, view_image, delete_image, edit_image, \
                 view_collection, delete_collection, upload_folder, add_image_for_neurosynth, \
                 serve_image, serve_pycortex, view_collection_with_pycortex, add_image, \
                 papaya_js_embed, view_images_by_tag, \
                 view_image_with_pycortex, stats_view, serve_nidm, serve_nidm_image, \
                 view_nidm_results, find_similar, compare_images, edit_metadata, \
-                export_images_filenames, delete_nidm_results
+                export_images_filenames, delete_nidm_results, view_task
 
 urlpatterns = patterns('',
     url(r'^my_collections/$',
@@ -143,13 +144,21 @@ urlpatterns = patterns('',
         serve_nidm,
         name='serve_nidm_files'),
 
-   # Compare images
+    # Compare images
     url(r'^images/compare/(?P<pk1>\d+)/(?P<pk2>\d+)$',
         compare_images,
         name='compare_images'),
     url(r'^images/(?P<pk>\d+)/find_similar$',
         find_similar,
-        name='find_similar')
+        name='find_similar'),
+
+    # Cognitive Atlas
+    url(r'^images/(?P<cog_atlas_id>[A-Za-z0-9].*)/task/json$',
+        ImagesByTaskJson.as_view(),
+        name='task_images_json'),
+    url(r'^images/(?P<cog_atlas_id>[A-Za-z0-9].*)/task$',
+        view_task,
+        name='view_task')
 
 )
 

--- a/neurovault/apps/statmaps/urls.py
+++ b/neurovault/apps/statmaps/urls.py
@@ -15,7 +15,7 @@ from .views import edit_collection, view_image, delete_image, edit_image, \
                 papaya_js_embed, view_images_by_tag, \
                 view_image_with_pycortex, stats_view, serve_nidm, serve_nidm_image, \
                 view_nidm_results, find_similar, compare_images, edit_metadata, \
-                export_images_filenames, delete_nidm_results, view_task
+                export_images_filenames, delete_nidm_results, view_task, search
 
 urlpatterns = patterns('',
     url(r'^my_collections/$',
@@ -144,19 +144,26 @@ urlpatterns = patterns('',
         serve_nidm,
         name='serve_nidm_files'),
 
-    # Compare images
+    # Compare images and search
     url(r'^images/compare/(?P<pk1>\d+)/(?P<pk2>\d+)$',
         compare_images,
         name='compare_images'),
     url(r'^images/(?P<pk>\d+)/find_similar$',
         find_similar,
         name='find_similar'),
+    url(r'^search$',
+        search,
+        name='search'),
+
 
     # Cognitive Atlas
     url(r'^images/(?P<cog_atlas_id>[A-Za-z0-9].*)/task/json$',
         ImagesByTaskJson.as_view(),
         name='task_images_json'),
     url(r'^images/(?P<cog_atlas_id>[A-Za-z0-9].*)/task$',
+        view_task,
+        name='view_task'),
+    url(r'^images/task$',
         view_task,
         name='view_task')
 

--- a/neurovault/apps/statmaps/utils.py
+++ b/neurovault/apps/statmaps/utils.py
@@ -1,5 +1,6 @@
 import errno
 import os
+import re
 import pickle
 import random
 import shutil

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -406,27 +406,28 @@ def view_task(request, cog_atlas_id=None):
         cog_atlas_id = request.POST["cogatlas"]
 
     if cog_atlas_id != None:
-        task = CognitiveAtlasTask.objects.filter(cog_atlas_id=cog_atlas_id)[0]
-        images = StatisticMap.objects.filter(cognitive_paradigm_cogatlas=task,collection__private=False)
+        task = CognitiveAtlasTask.objects.filter(cog_atlas_id=cog_atlas_id)
+        if len(task) != 0:
+            images = StatisticMap.objects.filter(cognitive_paradigm_cogatlas=task[0],collection__private=False)
     
-        graph,images_with_contrasts = get_task_graph(cog_atlas_id,get_images_with_contrasts=True)
+            graph,images_with_contrasts = get_task_graph(cog_atlas_id,get_images_with_contrasts=True)
 
-        # Which images aren't tagged with contrasts?
-        not_tagged = [i for i in images if i.pk not in images_with_contrasts]
+            # Which images aren't tagged with contrasts?
+            not_tagged = [i for i in images if i.pk not in images_with_contrasts]
 
-        context = {'task': task,
-                   'images': images,
-                   'cognitive_atlas_tree':graph,
-                   'tree_divid':"tree", # div id in template to append tree svg to
-                   'images_without_contrasts':not_tagged}
+            context = {'task': task[0],
+                       'images': images,
+                       'cognitive_atlas_tree':graph,
+                       'tree_divid':"tree", # div id in template to append tree svg to
+                       'images_without_contrasts':not_tagged}
 
-        if images.count()>0:
-            context["first_image"] = images[0]
+            if images.count()>0:
+                context["first_image"] = images[0]
 
-        return render(request, 'cogatlas/cognitive_atlas_task.html', context)
+            return render(request, 'cogatlas/cognitive_atlas_task.html', context)
 
     # Otherwise, direct back to search page
-    return search(request,error_message="Error querying Cognitive Atlas.")
+    return search(request,error_message="Invalid search for Cognitive Atlas.")
 
 
 @login_required
@@ -986,7 +987,7 @@ def find_similar(request,pk):
 # Return search interface
 def search(request,error_message=None):
     cogatlas_task = CognitiveAtlasTask.objects.all()
-    context = {'error_message': error_message,
+    context = {'message': error_message,
                'cogatlas_task': cogatlas_task}
     return render(request, 'statmaps/search.html', context)
 

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -403,12 +403,16 @@ def view_task(request, cog_atlas_id):
     task = CognitiveAtlasTask.objects.filter(cog_atlas_id=cog_atlas_id)[0]
     images = StatisticMap.objects.filter(cognitive_paradigm_cogatlas=task,collection__private=False)
     
-    graph = get_task_graph(cog_atlas_id)
+    graph,images_with_contrasts = get_task_graph(cog_atlas_id,get_images_with_contrasts=True)
+
+    # Which images aren't tagged with contrasts?
+    not_tagged = [i for i in images if i.pk not in images_with_contrasts]
 
     context = {'task': task,
                'images': images,
                'cognitive_atlas_tree':graph,
-               'tree_divid':"graph"} # div id in template to append tree svg to
+               'tree_divid':"tree", # div id in template to append tree svg to
+               'images_without_contrasts':not_tagged}
 
     if images.count()>0:
         context["first_image"] = images[0]

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -399,14 +399,21 @@ def view_task(request, cog_atlas_id):
     '''view_task returns a view to see a group of images associated with a particular cognitive atlas task.
     :param cog_atlas_id: statmaps.models.CognitiveAtlasTask the id for the task defined in the Cognitive Atlas
     '''
+    from cogat_functions import get_task_graph
     task = CognitiveAtlasTask.objects.filter(cog_atlas_id=cog_atlas_id)[0]
     images = StatisticMap.objects.filter(cognitive_paradigm_cogatlas=task,collection__private=False)
+    
+    graph = get_task_graph(cog_atlas_id)
 
     context = {'task': task,
-               'images': images}
+               'images': images,
+               'cognitive_atlas_tree':graph,
+               'tree_divid':"graph"} # div id in template to append tree svg to
 
-    return render(request, 'statmaps/cognitive_atlas_task.html', context)
+    if images.count()>0:
+        context["first_image"] = images[0]
 
+    return render(request, 'cogatlas/cognitive_atlas_task.html', context)
 
 @login_required
 def add_image_for_neurosynth(request):


### PR DESCRIPTION
This PR will do the following:

- adding a custom google search to the site
- adding a view to display a set of images based on cognitive atlas task

# Google Search

Google has a really nice [custom search](https://cse.google.com/cse/all) that was very easy to get working. There were some bugs with regard to the styling of the interface, but I've addressed them [like this](https://github.com/vsoch/NeuroVault/blob/enh/semantic-image-comparison/neurovault/apps/statmaps/templates/statmaps/search.html#L11).

The way to get to search is with a looking glass icon in the top right:

![image](https://cloud.githubusercontent.com/assets/814322/13064664/c42e00ca-d409-11e5-93fd-2fa4d6eed725.png)

The page is relatively simple: you can search google, or search to see images based on Cognitive Atlas Task:

![image](https://cloud.githubusercontent.com/assets/814322/13064458/d8a1e302-d407-11e5-8c3d-c12371939412.png)

The result is also pretty simple - it looks like standard google, and I maintained this because the user should know this.

![image](https://cloud.githubusercontent.com/assets/814322/13064468/039f14ee-d408-11e5-89d9-b4ff63345518.png)

Note the two labels for "images" and "collections" - I've added these based on a page url, with neurovault.org/images/* for pages, and neurovault.org/collections/* for collections, respectively. Also note that autocomplete is enabled, but it said it will take some time to "actually" start working. 

### Thumbnails
Thumbnails are enabled, meaning you can see images in results:

![image](https://cloud.githubusercontent.com/assets/814322/13064495/5013d350-d408-11e5-8331-7eed100ac1fd.png)

Importantly, I've updated the <meta> tags for the base collection and image view so that the statistical map nilearn image will be displayed as thumbnail. I haven't tested this, as it will take some unknown time for the Google bots to do their thing. Here is what meta data looks like for collections:

![image](https://cloud.githubusercontent.com/assets/814322/13064713/2aa9048a-d40a-11e5-9559-9994eefb0d9e.png)

and an image:

![image](https://cloud.githubusercontent.com/assets/814322/13064735/4d7f386c-d40a-11e5-831e-51c0fc657ff7.png)

# Cognitive Atlas Task View
In the case that the user clicks "Go" when the title is displayed (and there is an error), a message is displayed:

![image](https://cloud.githubusercontent.com/assets/814322/13064448/b136e768-d407-11e5-8e24-075babe7c5de.png)

We can use this functionality for other errors / messages that we might want to add in the future associated with search.

and the Cognitive Atlas task view has not changed, the first view shows all the images for the task:

![image](https://cloud.githubusercontent.com/assets/814322/13064817/fd36b0a0-d40a-11e5-866a-099cb76ac95b.png)

and the "Graph" tab shows an interactive tree. I changed the message slightly so it doesn't target the user "you" as needing to tag the missing images (because he/she likely won't be able to).

![image](https://cloud.githubusercontent.com/assets/814322/13064830/2c16f268-d40b-11e5-82b5-a8480c94c653.png)

### Bug

When we are in the search view, the collections tab is not functioning (likely a JavaScript conflict, either with select2 or the google insertion). I hope we can put our heads together and fix this, I couldn't off the bat.