### PR TITLE
Don't index private collections and images.

### DIFF
--- a/neurovault/apps/statmaps/templates/statmaps/_meta_collection.html
+++ b/neurovault/apps/statmaps/templates/statmaps/_meta_collection.html
@@ -1,6 +1,9 @@
 <meta name="pagetype" content="collection">
 <meta name="name" content="{{ collection.name }}">
 <meta name="database" content="neurovault.org">
+{% if collection.private %}
+<meta name="robots" content="noindex">
+{% endif %}
 {% if collection.authors %}
 <meta name="authors" content="{{ collection.authors }}">
 {% endif %}

--- a/neurovault/apps/statmaps/templates/statmaps/_meta_image.html
+++ b/neurovault/apps/statmaps/templates/statmaps/_meta_image.html
@@ -6,3 +6,6 @@
 <meta name="add_date" content="{{ image.add_date }}">
 <meta name="brain_coverage" content="{{ image.brain_coverage }}">
 <meta name="database" content="neurovault.org">
+{% if image.collection.private %}
+<meta name="robots" content="noindex">
+{% endif %}


### PR DESCRIPTION
If a link to a private collection is available online (publicly) google will index this collection. This is not our fault, but we can prevent this situation by suing noindex tags.