### PR TITLE
Fixing bugs for cognitive atlas view

### DIFF
--- a/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
@@ -110,7 +110,8 @@
                         %a{ href: "/images/tags/{{tag.name}}" }= tag.name
                         - if not forloop.last
 
-            %a.btn.btn-primary.btn{href: "{% url 'view_task' image.cognitive_paradigm_cogatlas_id %}"} Task View
+            - if image.cognitive_paradigm_cogatlas_id
+                %a.btn.btn-primary.btn{href: "{% url 'view_task' %}?cogatlas={{image.cognitive_paradigm_cogatlas_id}}"} Task View
             %a.btn.btn-primary.btn{href: "pycortex" } 3D View
             - if image.nidm_results
                 .btn-group


### PR DESCRIPTION
This will add a conditional statement to not show the "View Task" button if an image does not have a task defined, and change the URL format to be GET so that we don't get 500 errors.