### PR TITLE
Tweaks to Search and Cognitive Atlas Task View

### DIFF
--- a/neurovault/apps/main/templates/base.html
+++ b/neurovault/apps/main/templates/base.html
@@ -64,7 +64,7 @@
         <div class="collapse navbar-collapse" id="main-links">
             <ul class="nav navbar-nav">
                 <li class="dropdown">
-                    <a href="" class="dropdown-toggle" data-toggle="dropdown">
+                    <a href="" class="dropdown-toggle" id="collections_nav" data-toggle="dropdown">
                         Collections
                         <b class="caret"></b>
                     </a>

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
@@ -7,6 +7,10 @@
     <link href="http://netdna.bootstrapcdn.com/font-awesome/3.1.1/css/font-awesome.css" rel="stylesheet">
 
     <!--Meta data for Google Search-->
+    {% if no_task_images %}
+    <meta name="robots" content="noindex">
+    {% endif %}
+    
     <meta name="pagetype" content="cognitiveatlastask">
     <meta name="name" content="{{ task.name }}">
     <meta name="cognitive_paradigm_cogatlas" content="{{ task.name }}">
@@ -14,9 +18,10 @@
     <meta name="thumbnail" content="http://www.cognitiveatlas.org/images/logo-front.png">
     <meta name="database" content="neurovault.org">
     <meta name="url" content="http://www.cognitiveatlas.org/term/id/{{ task.cog_atlas_id }}">
-
+    
     <title>{% block title %}NeuroVault: {{ task.name }}{% endblock %}</title>
 
+    {% if not no_task_images %}
     <script type="text/javascript">
 
         var params = [];
@@ -172,6 +177,7 @@
         }).call(this);
 
     </script>
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -197,6 +203,16 @@
     <div class="row">
     </div>
 
+    {% if no_task_images %}
+    <div class="row" style="margin-bottom:30px">
+        <ul class="messages">
+        <div class="alert alert-dismissible alert-danger">
+        There are no maps in NeuroVault tagged with this task.
+        </div>
+        </ul>
+    </div>
+
+    {% else %}
     <!-- Content-->
 
     <!-- COLLECTION TABS -->
@@ -278,4 +294,5 @@
             });
         {% endif %}
     </script>
+{% endif %}
 {% endblock %}

--- a/neurovault/apps/statmaps/templates/statmaps/search.html
+++ b/neurovault/apps/statmaps/templates/statmaps/search.html
@@ -55,7 +55,7 @@ margin-top: 0 !important;
          <div class="row">
 
             <!-- Google Search Column-->
-            <div class="col-md-8" style="padding-top:30px;padding-bottom-20px;">
+            <div class="col-md-12" style="padding-top:30px;padding-bottom-20px;">
 		<script>
 		  (function() {
 		    var cx = '010503388974132107851:0z1x3cffi3u';
@@ -70,31 +70,17 @@ margin-top: 0 !important;
 		</script>
 		<gcse:search linkTarget="_self"></gcse:search>
             </div>
-
-            <!-- Cognitive Atlas Task Search Column -->
-            <div class="col-md-4" style="padding-top:45px">
-                <form action="{% url 'view_task' %}" method="get">
-                    <div class="form-group">
-                            <select class="form-control" id="cogatlas" name="cogatlas">
-                                <option>Search by Cognitive Atlas Task</option>
-                                    {% for task in cogatlas_task %}
-                                    <option value="{{ task.cog_atlas_id }}">{{ task.name }}</option>
-                                    {% endfor %}
-                            </select>
-                    </div>
-                    <input type="submit" class="btn btn-default btn-sm" value="Go">
-                </form>
-            </div>
          </div>
 
 </div>
 <div class="row">
 </div>
 
-<script type="text/javascript">
-   $(document).ready(function(){
-      $('#cogatlas').select2();
-   });
-
-</script> 
+<script>
+//Workaround to add collections link to dropdown
+$("#collections_nav").attr("href","{% url 'collections_list' %}")
+// Remove broken dropdown
+$("#collections_nav").children().remove()
+$("#collections_nav").removeAttr("data-toggle")
+</script>
 {% endblock %}

--- a/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
@@ -111,7 +111,7 @@
                         - if not forloop.last
 
             - if image.cognitive_paradigm_cogatlas_id
-                %a.btn.btn-primary.btn{href: "{% url 'view_task' %}?cogatlas={{image.cognitive_paradigm_cogatlas_id}}"} Task View
+                %a.btn.btn-primary.btn{href: "{% url 'view_task' image.cognitive_paradigm_cogatlas_id %}"} Task View
             %a.btn.btn-primary.btn{href: "pycortex" } 3D View
             - if image.nidm_results
                 .btn-group

--- a/neurovault/apps/statmaps/urls.py
+++ b/neurovault/apps/statmaps/urls.py
@@ -162,9 +162,6 @@ urlpatterns = patterns('',
         name='task_images_json'),
     url(r'^tasks/(?P<cog_atlas_id>[A-Za-z0-9].*)$',
         view_task,
-        name='view_task'),
-    url(r'^tasks$',
-        view_task,
         name='view_task')
 
 )

--- a/neurovault/apps/statmaps/urls.py
+++ b/neurovault/apps/statmaps/urls.py
@@ -162,6 +162,9 @@ urlpatterns = patterns('',
         name='task_images_json'),
     url(r'^tasks/(?P<cog_atlas_id>[A-Za-z0-9].*)$',
         view_task,
+        name='view_task'),
+    url(r'^tasks$',
+        view_task,
         name='view_task')
 
 )

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -401,9 +401,9 @@ def view_task(request, cog_atlas_id=None):
     '''
     from cogat_functions import get_task_graph
 
-    # Get the cognitive atlas id from the get (given a form submit)
+    # Get the cognitive atlas id
     if not cog_atlas_id:
-        cog_atlas_id = request.GET["cogatlas"]
+        return search(request, error_message="Please search for a Cognitive Atlas task to see the task view.")
 
     try:
         task = CognitiveAtlasTask.objects.get(cog_atlas_id=cog_atlas_id)
@@ -429,7 +429,11 @@ def view_task(request, cog_atlas_id=None):
 
             return render(request, 'cogatlas/cognitive_atlas_task.html', context)
 
-    return search(request, error_message="No tagged images found in NeuroVault for this Cognitive Atlas task.")
+    # If task does not have images   
+    context = {"no_task_images": True, # robots won't index page if defined
+               "task": task } 
+    return render(request, 'cogatlas/cognitive_atlas_task.html', context)
+
 
 
 @login_required


### PR DESCRIPTION
This PR will do the following:

### Search Box Removed
remove explicit task search box - it's now just a row --> column of width 12:

![image](https://cloud.githubusercontent.com/assets/814322/13443152/aea8afc8-dfb4-11e5-9a2e-52ecb85b4ec1.png)

### GET requests removed
remove code for handling GET requests (we are not using them anymore)

- GET is removed from [main function to view a task](https://github.com/NeuroVault/NeuroVault/compare/master...vsoch:fix/search?expand=1#diff-7129b607d02d4a1b46380abd3fd7d834R406)

This also means [changing the url](https://github.com/NeuroVault/NeuroVault/compare/master...vsoch:fix/search?expand=1#diff-011c1a7abfcd5bcca6590629636105baR114) on the statisticmaps pages (no other pages right?)

### View Task Function Changes
The new flow of the view_task function is as follows:

1) if user navigated to neurovault.org/tasks and there is no ID specified, we show them this:

![image](https://cloud.githubusercontent.com/assets/814322/13443306/67aa346a-dfb5-11e5-8a06-4e926f19bdb5.png)

If an ID is given, we then look for the task id in the database. If it doesn't exist, we show them this: 

![image](https://cloud.githubusercontent.com/assets/814322/13443347/8abeec66-dfb5-11e5-9c64-66bfdd46925f.png)

If the ID is valid, we now have two options. We either have images tagged in the database, or not. If we do:

![image](https://cloud.githubusercontent.com/assets/814322/13443400/ba95abe6-dfb5-11e5-9c91-401b203b8aca.png)

If we do not:

![image](https://cloud.githubusercontent.com/assets/814322/13443491/1ec43628-dfb6-11e5-9779-45329fd3317e.png)

If we look at the header of this page, it will not be indexed by robots:

![image](https://cloud.githubusercontent.com/assets/814322/13443548/4ffcd538-dfb6-11e5-933f-89be3ba1106b.png)

I left the other meta tags, since it doesn't hurt to still have them, but if it might be better to remove them, that's an option. I didn't see any harm in keeping them. If the task does have images, we do index:

![image](https://cloud.githubusercontent.com/assets/814322/13443582/7f4a03f6-dfb6-11e5-85f6-cdd50f5e3f6d.png)