### PR TITLE
Changed default list size for collections, images, collection index and tag listing to 25.

### DIFF
--- a/neurovault/api/serializers.py
+++ b/neurovault/api/serializers.py
@@ -265,7 +265,11 @@ class CollectionSerializer(serializers.ModelSerializer):
     images = ImageSerializer(many=True, source='basecollectionitem_set')
     contributors = SerializedContributors(required=False)
     owner_name = serializers.SerializerMethodField()
+    number_of_images = serializers.SerializerMethodField('num_im')
 
+    def num_im(self, obj):
+        return obj.basecollectionitem_set.count()
+        
     def get_owner_name(self, obj):
         return obj.owner.username
 

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
@@ -10,7 +10,7 @@
     {% if no_task_images %}
     <meta name="robots" content="noindex">
     {% endif %}
-    
+
     <meta name="pagetype" content="cognitiveatlastask">
     <meta name="name" content="{{ task.name }}">
     <meta name="cognitive_paradigm_cogatlas" content="{{ task.name }}">
@@ -18,7 +18,7 @@
     <meta name="thumbnail" content="http://www.cognitiveatlas.org/images/logo-front.png">
     <meta name="database" content="neurovault.org">
     <meta name="url" content="http://www.cognitiveatlas.org/term/id/{{ task.cog_atlas_id }}">
-    
+
     <title>{% block title %}NeuroVault: {{ task.name }}{% endblock %}</title>
 
     {% if not no_task_images %}
@@ -280,7 +280,7 @@
                     "processing": true,
                     "serverSide": true,
                     "pagingType": "full",
-					"iDisplayLength": 25,
+					"iDisplayLength": 7,
                     "lengthMenu": [7, 10, 25, 50, 75, 100],
                     "columnDefs": [
                         {"orderable": false, "targets": 0}

--- a/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
+++ b/neurovault/apps/statmaps/templates/cogatlas/cognitive_atlas_task.html
@@ -280,6 +280,7 @@
                     "processing": true,
                     "serverSide": true,
                     "pagingType": "full",
+					"iDisplayLength": 25,
                     "lengthMenu": [7, 10, 25, 50, 75, 100],
                     "columnDefs": [
                         {"orderable": false, "targets": 0}

--- a/neurovault/apps/statmaps/templates/statmaps/atlas_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/atlas_details.html.haml
@@ -24,7 +24,7 @@
                 $("table[class*=image-details-datatable]").dataTable
                     sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>"
                     sAjaxSource: "/api/images/" + "{{ api_cid }}" + "/datatable/?format=json"
-                    iDisplayLength: 10
+                    iDisplayLength: 25
                 $("table[class*=image-regions-datatable]").dataTable
                     sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>"
                     sAjaxSource: "/api/atlases/" + "{{ api_cid }}" + "/regions_table/?format=json"

--- a/neurovault/apps/statmaps/templates/statmaps/atlas_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/atlas_details.html.haml
@@ -24,11 +24,11 @@
                 $("table[class*=image-details-datatable]").dataTable
                     sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>"
                     sAjaxSource: "/api/images/" + "{{ api_cid }}" + "/datatable/?format=json"
-                    iDisplayLength: 25
+                    iDisplayLength: 7
                 $("table[class*=image-regions-datatable]").dataTable
                     sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>"
                     sAjaxSource: "/api/atlases/" + "{{ api_cid }}" + "/regions_table/?format=json"
-                    iDisplayLength: 25
+                    iDisplayLength: 7
 
                 $('#delete_image').click((e) ->
                     confirm("Are you sure you want to delete this image? This operation cannot be undone!")

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html
@@ -358,7 +358,8 @@ $(document).ready(function() {
         "processing": true,
         "serverSide": true,
         "pagingType": "full",
-        "lengthMenu": [ 7, 10, 25, 50, 75, 100 ],
+		"iDisplayLength": 25,
+        "lengthMenu": [7, 10, 25, 50, 75, 100],
         "columnDefs": [
     		{ "orderable": false, "targets": 0 }
   		],

--- a/neurovault/apps/statmaps/templates/statmaps/collection_details.html
+++ b/neurovault/apps/statmaps/templates/statmaps/collection_details.html
@@ -14,7 +14,7 @@
 <script type="text/javascript">
 
 var params = [];
-     
+
 {% if first_image %}
    var tmpname = "{{ first_image.file.url }}".replace(/^.*[\\\/]/, '')
     {% if first_image.map_type == 'Pa' or first_image.polymorphic_ctype.model == 'atlas' %}
@@ -56,7 +56,7 @@ var params = [];
 
 <script type='text/javascript'>
 
- function showLoader() {   
+ function showLoader() {
     document.getElementById('spinny').style.display = 'block';
     document.getElementById('fade').style.display = 'block';
   }
@@ -98,7 +98,7 @@ var params = [];
 
       papaya.Container.resetViewer(0, params);  // specify new ones
       $(mrimage).addClass("active")
-  
+
   }
 
 (function() {
@@ -145,15 +145,15 @@ var params = [];
           }
         }
       }
-      
+
       csrftoken = $.cookie('csrftoken');
       xhr.open('POST', "upload_folder", true);
       xhr.setRequestHeader("X-CSRFToken", csrftoken);
       xhr.onloadstart = function(e){
-                $('.modal-backdrop').removeClass("modal-backdrop"); 
+                $('.modal-backdrop').removeClass("modal-backdrop");
                 showLoader();
       };
-      
+
       // We need to know when the request finishes.
       xhr.onload = function (e) {
       if (xhr.status === 200) {
@@ -235,10 +235,10 @@ var params = [];
                     <a class="btn btn-primary dropdown-toggle" href="#" data-toggle="dropdown">Upload<span class="caret"></span></a>
                     <ul class="dropdown-menu">
                         <li><a id="upload_archive" href="#">Archive (.zip)</a></li>
-                        <!--[if !IE]> -->                               
+                        <!--[if !IE]> -->
                         <li><a id="upload_folder" href="#">Folder</a></li>
                         <!-- <![endif]-->
-                    </ul>                      
+                    </ul>
                 </div>
                 {% endif %}<!-- close if images -->
 
@@ -273,7 +273,7 @@ var params = [];
 <!-- Content-->
 <div class="row">
 
-<div class="col-md-6" style="margin-top:20px">    
+<div class="col-md-6" style="margin-top:20px">
     <div class="papaya" data-params="params" style="width:560px; float:left;"></div>
 </div>
 <div class="col-md-6">
@@ -314,8 +314,8 @@ var params = [];
               {% endif %} <!-- close if not empty -->
               </form>
 
-              </div><!-- Close images tab-->  
-              
+              </div><!-- Close images tab-->
+
               {% if not is_empty %}
               <div id="details" class="tab-pane">
                   <table id="collection-details-datatable" class="compact">
@@ -338,7 +338,7 @@ var params = [];
                   </table>
               </div><!-- close details tab-->
               {% endif %}
-              <div id="upload_process" class="modal" style="margin-top: 175px;" data-keyboard="false"></div>               
+              <div id="upload_process" class="modal" style="margin-top: 175px;" data-keyboard="false"></div>
          </div><!-- close tab content-->
     </div>
 </div>
@@ -358,7 +358,7 @@ $(document).ready(function() {
         "processing": true,
         "serverSide": true,
         "pagingType": "full",
-		"iDisplayLength": 25,
+		"iDisplayLength": 7,
         "lengthMenu": [7, 10, 25, 50, 75, 100],
         "columnDefs": [
     		{ "orderable": false, "targets": 0 }

--- a/neurovault/apps/statmaps/templates/statmaps/collections_index.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/collections_index.html.haml
@@ -7,7 +7,7 @@
        $(document).ready(function() {
           $('#collections-table').dataTable({
                     sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>",
-                    iDisplayLength: 10,
+                    iDisplayLength: 25,
                     aoColumns: [ { sWidth: '40%' }, { sWidth: '10%'}, { sWidth: '45%'}, { sWidth: '5%'}],
                     "processing": true,
         			"serverSide": true,

--- a/neurovault/apps/statmaps/templates/statmaps/images_by_tag.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/images_by_tag.html.haml
@@ -9,7 +9,7 @@
         $(document).ready ->
             $("table").dataTable
                 sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>"
-                iDisplayLength: 10
+                iDisplayLength: 25
                 aoColumns: [ { sWidth: '6%'}, { sWidth: '20%' }, { sWidth: '20%'}, { sWidth: '54%'}]
                 fnRowCallback: (nRow, aData, iDisplayIndex) ->
                     nRow

--- a/neurovault/apps/statmaps/templates/statmaps/my_collections.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/my_collections.html.haml
@@ -7,7 +7,7 @@
        $(document).ready(function() {
           $('#collections-table').dataTable({
                     sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>",
-                    iDisplayLength: 10,
+                    iDisplayLength: 25,
                     aoColumns: [ { sWidth: '40%' }, { sWidth: '10%'}, { sWidth: '45%'}, { sWidth: '5%'}],
                     "processing": true,
         			"serverSide": true,

--- a/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
@@ -77,7 +77,7 @@
                 $("table[class*=image-details-datatable]").dataTable
                     sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>"
                     sAjaxSource: "/api/images/" + "{{ api_cid }}" + "/datatable/?format=json"
-                    iDisplayLength: 25
+                    iDisplayLength: 7
 
                 $('#delete_image').click((e) ->
                     confirm("Are you sure you want to delete this image? This operation cannot be undone!")

--- a/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
@@ -77,7 +77,7 @@
                 $("table[class*=image-details-datatable]").dataTable
                     sDom: "<'row-fluid'<'span6'l><'span6'f>r>t<'row-fluid'<'span6'i><'span6'p>>"
                     sAjaxSource: "/api/images/" + "{{ api_cid }}" + "/datatable/?format=json"
-                    iDisplayLength: 10
+                    iDisplayLength: 25
 
                 $('#delete_image').click((e) ->
                     confirm("Are you sure you want to delete this image? This operation cannot be undone!")

--- a/neurovault/apps/statmaps/templates/statmaps/tags_index.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/tags_index.html.haml
@@ -9,7 +9,7 @@
                     # sDom: "<'row'<'span5'f>r>t<'row-fluid'<'span6'i><'span6'p>>"
                     sDom: "fit"
                     sPaginationType: "bootstrap"
-                    iDisplayLength: 10
+                    iDisplayLength: 25
                     fnRowCallback: (nRow, aData, iDisplayIndex) ->
                         $cell=$('td:eq(0)', nRow)
                         tag_name = $cell.text()


### PR DESCRIPTION
This solves issue #352 , but can be discussed if it's appropriate to show that fixed amount of images, tags, collections. Now it is easy to change this default setting. Also, there is the option of showing 'all' instances, in case you thing that would be interesting (it is a bit dangerous too, since it could overload the db when the project grows). 