### PR TITLE
Fix an ImproperlyConfigured exception when updating oauth app

### DIFF
--- a/neurovault/apps/users/forms.py
+++ b/neurovault/apps/users/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth.models import User
-from django.contrib.auth.forms import UserCreationForm, UserChangeForm
+from django.contrib.auth.forms import UserCreationForm
 from django.utils.translation import ugettext_lazy as _
 from oauth2_provider.models import Application
 

--- a/neurovault/apps/users/tests/test_application_views.py
+++ b/neurovault/apps/users/tests/test_application_views.py
@@ -1,0 +1,97 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.core.urlresolvers import reverse
+
+from oauth2_provider.models import Application
+
+UserModel = get_user_model()
+
+
+class BaseTest(TestCase):
+    def setUp(self):
+        self.user_password = 'random'
+        self.user = UserModel.objects.create_user("neurouser",
+                                                  "neurouser@example.com",
+                                                  self.user_password)
+
+    def tearDown(self):
+        self.user.delete()
+
+
+class TestApplicationRegistrationView(BaseTest):
+
+    def test_application_registration_user(self):
+        self.client.login(username=self.user.username,
+                          password=self.user_password)
+
+        form_data = {
+            'name': 'Random App',
+            'client_id': 'client_id',
+            'client_secret': 'client_secret',
+            'client_type': Application.CLIENT_CONFIDENTIAL,
+            'redirect_uris': 'http://example.com',
+            'authorization_grant_type': Application.GRANT_AUTHORIZATION_CODE
+        }
+
+        response = self.client.post(reverse('developerapps_register'),
+                                    form_data)
+        self.assertEqual(response.status_code, 302)
+
+        app = Application.objects.get(name="Random App")
+        self.assertEqual(app.user.username, self.user.username)
+
+
+class TestApplicationViews(BaseTest):
+    def _create_application(self, name, user):
+        app = Application.objects.create(
+            name=name,
+            redirect_uris="http://example.com",
+            client_type=Application.CLIENT_CONFIDENTIAL, authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=user
+        )
+        return app
+
+    def setUp(self):
+        super(TestApplicationViews, self).setUp()
+        self.app = self._create_application('app 1', self.user)
+
+    def tearDown(self):
+        super(TestApplicationViews, self).tearDown()
+        self.app.delete()
+
+    def test_application_list(self):
+        self.client.login(username=self.user.username,
+                          password=self.user_password)
+
+        response = self.client.get(reverse('developerapps_list'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['object_list']), 1)
+
+    def test_application_detail(self):
+        self.client.login(username=self.user.username,
+                          password=self.user_password)
+
+        response = self.client.get(reverse('developerapps_update',
+                                   args=(self.app.pk,)))
+        self.assertEqual(response.status_code, 200)
+
+    def test_application_update(self):
+        self.client.login(username=self.user.username,
+                          password=self.user_password)
+
+        form_data = {
+            'name': 'Changed App',
+            'client_id': 'client_id',
+            'client_secret': 'client_secret',
+            'client_type': Application.CLIENT_CONFIDENTIAL,
+            'redirect_uris': 'http://example.com',
+            'authorization_grant_type': Application.GRANT_AUTHORIZATION_CODE
+        }
+
+        response = self.client.post(reverse('developerapps_update',
+                                    args=(self.app.pk,)),
+                                    form_data)
+        self.assertEqual(response.status_code, 302)
+
+        app = Application.objects.get(name="Changed App")
+        self.assertEqual(app.user.username, self.user.username)

--- a/neurovault/apps/users/views.py
+++ b/neurovault/apps/users/views.py
@@ -166,8 +166,11 @@ class ApplicationUpdate(ApplicationOwnerIsUserMixin, UpdateView):
     View used to update an application owned by the request.user
     """
     context_object_name = 'application'
-    form_class = ApplicationEditForm
     template_name = 'oauth2_provider/application_form.html'
+
+    # Reset the inherited fields attribute and use a form_class instead
+    fields = None
+    form_class = ApplicationEditForm
 
     def get_success_url(self):
         return reverse('developerapps_list')


### PR DESCRIPTION
This adds tests and fixes for E#184 in Opbeat.

The exception was caused by having both `fields` and `form_class` attributes set in `ApplicationUpdate` view class. Where `form_class` was specified explicitly,  `fields` was inherited from a base class. Looks like the presence of both attributes was ok in Django < 1.8 and not ok in recent versions.