### PR TITLE
Neurovault - Neuropower integration

### DIFF
--- a/neurovault/apps/statmaps/forms.py
+++ b/neurovault/apps/statmaps/forms.py
@@ -669,6 +669,10 @@ class SimplifiedStatisticMapForm(EditStatisticMapForm):
                   'perc_bad_voxels')
 
 class NeuropowerStatisticMapForm(EditStatisticMapForm):
+    def __init__(self, *args, **kwargs):
+        super(NeuropowerStatisticMapForm, self).__init__(*args, **kwargs)
+        self.fields['analysis_level'].required = True
+        self.fields['number_of_subjects'].required = True
 
     class Meta(EditStatisticMapForm.Meta):
         fields = ('name', 'collection', 'description', 'map_type', 'modality', 'map_type','analysis_level','number_of_subjects','cognitive_paradigm_cogatlas',

--- a/neurovault/apps/statmaps/forms.py
+++ b/neurovault/apps/statmaps/forms.py
@@ -637,7 +637,7 @@ class EditStatisticMapForm(StatisticMapForm):
 class AddStatisticMapForm(StatisticMapForm):
 
     class Meta(StatisticMapForm.Meta):
-        fields = ('name', 'description', 'map_type', 'modality', 'cognitive_paradigm_cogatlas', 
+        fields = ('name', 'description', 'map_type', 'modality', 'cognitive_paradigm_cogatlas',
                   'cognitive_contrast_cogatlas', 'analysis_level', 'number_of_subjects', 'contrast_definition', 'figure',
                   'file', 'ignore_file_warning', 'hdr_file', 'tags', 'statistic_parameters',
                   'smoothness_fwhm', 'is_thresholded', 'perc_bad_voxels')
@@ -665,6 +665,13 @@ class SimplifiedStatisticMapForm(EditStatisticMapForm):
 
     class Meta(EditStatisticMapForm.Meta):
         fields = ('name', 'collection', 'description', 'map_type', 'modality', 'cognitive_paradigm_cogatlas',
+                  'cognitive_contrast_cogatlas', 'file', 'ignore_file_warning', 'hdr_file', 'tags', 'is_thresholded',
+                  'perc_bad_voxels')
+
+class NeuropowerStatisticMapForm(EditStatisticMapForm):
+
+    class Meta(EditStatisticMapForm.Meta):
+        fields = ('name', 'collection', 'description', 'map_type', 'modality', 'map_type','analysis_level','number_of_subjects','cognitive_paradigm_cogatlas',
                   'cognitive_contrast_cogatlas', 'file', 'ignore_file_warning', 'hdr_file', 'tags', 'is_thresholded',
                   'perc_bad_voxels')
 

--- a/neurovault/apps/statmaps/templates/statmaps/add_image_for_neuropower.html
+++ b/neurovault/apps/statmaps/templates/statmaps/add_image_for_neuropower.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% load static from staticfiles %}
+
+{% block head %}
+    <link href="{% static 'css/studies.css' %}" media="screen" rel="stylesheet" type="text/css"/>
+    <script src="{% static "scripts/select2.min.js"%}" type="text/javascript"></script>
+    <link rel="stylesheet" href="{% static "css/select2.min.css" %}" />
+    <title>{% block title %}Add a new image{% endblock %}</title>
+{% endblock %}
+
+{% block content %}
+    <div class="col-md-11">
+        <h2>Upload a map to perform a power analysis with Neuropower</h2>
+        <div class="row">
+            <div class="col-md-9">
+                <p>Welcome to NeuroVault - a  public web repository for statistical
+                        maps of the human brain. After filling in the minimum
+                        information outlined below (only the fields with an
+                        asterisk [*] are compulsory), your map
+                        will be sent back to <a href="http://neuropowertools.org">Neuropowertools.org</a> for
+                        a power analysis. Your (pilot or preliminary) data will not be public, but we strongly encourage you to upload your full dataset after collection to Neurovault and make it public.
+  			You can always come back to <a href="/">NeuroVault.org</a> to
+			inspect, modify, and/or delete your maps. 
+                </p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-11">
+        <hr>
+        <form  class="form-horizontal" method="post"  enctype="multipart/form-data">
+    		{% crispy form %}
+	</form>
+    </div>
+
+    {% include "statmaps/_contrast_lookup.html" %}
+
+{% endblock %}

--- a/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/statisticmap_details.html.haml
@@ -141,6 +141,7 @@
             - else
                 %a.btn.btn-primary.btn{href: "{{ image.file.url|urlencode }}" } Download
             %a.btn.btn-primary.btn{href: "http://neurosynth.org/decode/?neurovault={{ api_cid }}" } Decode with neurosynth
+            %a.btn.btn-primary.btn{href: "http://neuropowertools.org/neuropowerinput/?neurovault={{ api_cid }}" } Perform power analysis
             - if comparison_is_possible
                 %a.btn.btn-primary.btn{href: "{% url 'find_similar' image.id %}", data-toggle: "tooltip", title: "Find maps with similar patters."} Find similar
             - else

--- a/neurovault/apps/statmaps/urls.py
+++ b/neurovault/apps/statmaps/urls.py
@@ -12,7 +12,7 @@ from neurovault.apps.statmaps.views import ImagesInCollectionJson,\
 from .views import edit_collection, view_image, delete_image, edit_image, \
                 view_collection, delete_collection, upload_folder, add_image_for_neurosynth, \
                 serve_image, serve_pycortex, view_collection_with_pycortex, add_image, \
-                papaya_js_embed, view_images_by_tag, \
+                papaya_js_embed, view_images_by_tag, add_image_for_neuropower, \
                 view_image_with_pycortex, stats_view, serve_nidm, serve_nidm_image, \
                 view_nidm_results, find_similar, compare_images, edit_metadata, \
                 export_images_filenames, delete_nidm_results, view_task, search
@@ -100,6 +100,9 @@ urlpatterns = patterns('',
     url(r'^images/add_for_neurosynth$',
         add_image_for_neurosynth,
         name='add_for_neurosynth'),
+    url(r'^images/add_for_neuropower$',
+        add_image_for_neuropower,
+        name='add_for_neuropower'),
     url(r'^images/(?P<pk>\d+)/js/embed$',
         papaya_js_embed,
         name='papaya_js_embed'),

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -434,7 +434,7 @@ def view_task(request, cog_atlas_id=None):
                "task": task }
     return render(request, 'cogatlas/cognitive_atlas_task.html', context)
 
-def add_image_redirect(request,app,template_path,redirect_url,is_private):
+def add_image_redirect(request,formclass,template_path,redirect_url,is_private):
     temp_collection_name = "%s's temporary collection" % request.user.username
     #this is a hack we need to make sure this collection can be only
     #owned by the same user
@@ -451,18 +451,12 @@ def add_image_redirect(request,app,template_path,redirect_url,is_private):
     redirect = redirect_url+"/?neurovault=%s-%s" % (
         temp_collection.private_token,image.id)
     if request.method == "POST":
-        if app == "neurosynth":
-            form = SimplifiedStatisticMapForm(request.POST, request.FILES, instance=image, user=request.user)
-        elif app == "neuropower":
-            form = NeuropowerStatisticMapForm(request.POST, request.FILES, instance=image, user=request.user)
+        form = formclass(request.POST, request.FILES, instance=image, user=request.user)
         if form.is_valid():
             image = form.save()
-            return HttpResponseRedirect(redirect)
+        return HttpResponseRedirect(redirect)
     else:
-        if app == "neurosynth":
-            form = SimplifiedStatisticMapForm(user=request.user, instance=image)
-        elif app == "neuropower":
-            form = NeuropowerStatisticMapForm(user=request.user, instance=image)
+        form = formclass(user=request.user, instance=image)
     contrasts = get_contrast_lookup()
     context = {"form": form,"contrasts":json.dumps(contrasts)}
     return render(request,template_path , context)
@@ -471,13 +465,13 @@ def add_image_redirect(request,app,template_path,redirect_url,is_private):
 def add_image_for_neurosynth(request):
     redirect_url = "http://neurosynth.org/decode"
     template_path = "statmaps/add_image_for_neurosynth.html"
-    return add_image_redirect(request,"neurosynth",template_path,redirect_url,False)
+    return add_image_redirect(request,SimplifiedStatisticMapForm,template_path,redirect_url,False)
 
 @login_required
 def add_image_for_neuropower(request):
     redirect_url = "http://neuropowertools.org/neuropowerinput/"
     template_path = "statmaps/add_image_for_neuropower.html"
-    return add_image_redirect(request,"neuropower",template_path,redirect_url,True)
+    return add_image_redirect(request,NeuropowerStatisticMapForm,template_path,redirect_url,True)
 
 @login_required
 def add_image(request, collection_cid):

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -434,64 +434,50 @@ def view_task(request, cog_atlas_id=None):
                "task": task }
     return render(request, 'cogatlas/cognitive_atlas_task.html', context)
 
-
+def add_image_redirect(request,app,template_path,redirect_url,is_private):
+    temp_collection_name = "%s's temporary collection" % request.user.username
+    #this is a hack we need to make sure this collection can be only
+    #owned by the same user
+    try:
+        temp_collection = Collection.objects.get(name=temp_collection_name)
+    except Collection.DoesNotExist:
+        priv_token = generate_url_token()
+        temp_collection = Collection(name=temp_collection_name,
+                                     owner=request.user,
+                                     private=is_private,
+                                     private_token=priv_token)
+        temp_collection.save()
+    image = StatisticMap(collection=temp_collection)
+    redirect = redirect_url+"/?neurovault=%s-%s" % (
+        temp_collection.private_token,image.id)
+    if request.method == "POST":
+        if app == "neurosynth":
+            form = SimplifiedStatisticMapForm(request.POST, request.FILES, instance=image, user=request.user)
+        elif app == "neuropower":
+            form = NeuropowerStatisticMapForm(request.POST, request.FILES, instance=image, user=request.user)
+        if form.is_valid():
+            image = form.save()
+            return HttpResponseRedirect(redirect)
+    else:
+        if app == "neurosynth":
+            form = SimplifiedStatisticMapForm(user=request.user, instance=image)
+        elif app == "neuropower":
+            form = NeuropowerStatisticMapForm(user=request.user, instance=image)
+    contrasts = get_contrast_lookup()
+    context = {"form": form,"contrasts":json.dumps(contrasts)}
+    return render(request,template_path , context)
 
 @login_required
 def add_image_for_neurosynth(request):
-    temp_collection_name = "%s's temporary collection" % request.user.username
-    #this is a hack we need to make sure this collection can be only
-    #owned by the same user
-    try:
-        temp_collection = Collection.objects.get(name=temp_collection_name)
-    except Collection.DoesNotExist:
-        priv_token = generate_url_token()
-        temp_collection = Collection(name=temp_collection_name,
-                                     owner=request.user,
-                                     private=False,
-                                     private_token=priv_token)
-        temp_collection.save()
-    image = StatisticMap(collection=temp_collection)
-    if request.method == "POST":
-        form = SimplifiedStatisticMapForm(request.POST, request.FILES, instance=image, user=request.user)
-        if form.is_valid():
-            image = form.save()
-            return HttpResponseRedirect("http://neurosynth.org/decode/?neurovault=%s-%s" % (
-                temp_collection.private_token,image.id))
-    else:
-        form = SimplifiedStatisticMapForm(user=request.user, instance=image)
-
-    contrasts = get_contrast_lookup()
-    context = {"form": form,"contrasts":json.dumps(contrasts)}
-    return render(request, "statmaps/add_image_for_neurosynth.html", context)
+    redirect_url = "http://neurosynth.org/decode"
+    template_path = "statmaps/add_image_for_neurosynth.html"
+    return add_image_redirect(request,"neurosynth",template_path,redirect_url,False)
 
 @login_required
 def add_image_for_neuropower(request):
-    temp_collection_name = "%s's temporary collection" % request.user.username
-    #this is a hack we need to make sure this collection can be only
-    #owned by the same user
-    try:
-        temp_collection = Collection.objects.get(name=temp_collection_name)
-    except Collection.DoesNotExist:
-        priv_token = generate_url_token()
-        temp_collection = Collection(name=temp_collection_name,
-                                     owner=request.user,
-                                     private=True,
-                                     private_token=priv_token)
-        temp_collection.save()
-    image = StatisticMap(collection=temp_collection)
-    if request.method == "POST":
-        form = NeuropowerStatisticMapForm(request.POST, request.FILES, instance=image, user=request.user)
-        if form.is_valid():
-            image = form.save()
-            return HttpResponseRedirect("http://neuropowertools.org/neuropowerinput/?neurovault=%s-%s" % (
-                temp_collection.private_token,image.id))
-    else:
-        form = NeuropowerStatisticMapForm(user=request.user, instance=image)
-
-    contrasts = get_contrast_lookup()
-    context = {"form": form,"contrasts":json.dumps(contrasts)}
-    return render(request, "statmaps/add_image_for_neuropower.html", context)
-
+    redirect_url = "http://neuropowertools.org/neuropowerinput/"
+    template_path = "statmaps/add_image_for_neuropower.html"
+    return add_image_redirect(request,"neuropower",template_path,redirect_url,True)
 
 @login_required
 def add_image(request, collection_cid):


### PR DESCRIPTION
There are two main parts of this pull request:
1. A button is added to the image pages on [neurovault](http://www.neurovault.org).  This button redirects to [neuropower](http://www.neuropowertools.org) and fills out the form with data from the neurovault API, similar to the [neurosynth](http://www.neurosynth.org) button.
2. A specific data upload page has been created on [neurovault](http://www.neurovault.org) for power analysis.  This page allows with one page the upload of a new image, also similar to what is in [neurosynth](http://www.neurosynth.org).  The form is specific to the necessary input for neuropower.  Images are by default hidden, as these data are supposed to be from pilot or incomplete studies.