### PR TITLE
[WIP] Cleans tags (lowercases them)

### DIFF
--- a/neurovault/apps/statmaps/forms.py
+++ b/neurovault/apps/statmaps/forms.py
@@ -493,6 +493,7 @@ class StatisticMapForm(ImageForm):
         django_file = cleaned_data.get("file")
 
         cleaned_data["is_valid"] = True #This will be only saved if the form will validate
+        cleaned_data["tags"] = clean_tags(cleaned_data)
 
         if django_file and "file" not in self._errors and "hdr_file" not in self._errors:
             django_file.open()
@@ -948,3 +949,14 @@ class EditNIDMResultStatisticMapForm(NIDMResultStatisticMapForm):
 
     def __init__(self, user, *args, **kwargs):
         super(EditNIDMResultStatisticMapForm, self).__init__(*args, **kwargs)
+
+
+def clean_tags(self):
+    """
+    Force all tags to lowercase.
+    """
+    tags = self.get('tags', None)
+    if tags:
+        tags = [t.lower() for t in tags]
+
+    return tags


### PR DESCRIPTION
This PR cleans the tags from a form, lowercasing them. I am not sure if this only applies for StatisticMapForms, I've been testing with several image types. 