### PR TITLE
Changed tagcleaning to ImageForm and added in NIDMform

### DIFF
--- a/neurovault/apps/statmaps/forms.py
+++ b/neurovault/apps/statmaps/forms.py
@@ -476,6 +476,7 @@ class ImageForm(ModelForm, ImageValidationMixin):
 
     def clean(self, **kwargs):
         cleaned_data = super(ImageForm, self).clean()
+        cleaned_data["tags"] = clean_tags(cleaned_data)
         return self.clean_and_validate(cleaned_data)
 
 
@@ -493,7 +494,6 @@ class StatisticMapForm(ImageForm):
         django_file = cleaned_data.get("file")
 
         cleaned_data["is_valid"] = True #This will be only saved if the form will validate
-        cleaned_data["tags"] = clean_tags(cleaned_data)
 
         if django_file and "file" not in self._errors and "hdr_file" not in self._errors:
             django_file.open()
@@ -873,6 +873,7 @@ class NIDMResultsForm(forms.ModelForm, NIDMResultsValidationMixin):
 
     def clean(self):
         cleaned_data = super(NIDMResultsForm, self).clean()
+        cleaned_data["tags"] = clean_tags(cleaned_data)
         # only process new uploads or replaced zips
         if self.instance.pk is None or 'zip_file' in self.changed_data:
             self.cleaned_data = self.clean_and_validate(cleaned_data)


### PR DESCRIPTION
Changed clean_tag() to ImageForm and added into NIDMResultsForm. With this PR, we can avoid errors; probably the last migration has to be executed again, since there will be some duplicated tags due to the pair of errors generated...

While doing this, I've realized that  NIDM tags don't appear in the NIDM view and neither are being indexed by the tag_search (NIDM tags do exist, but they are not being used at all). Maybe this is due to a bad use from my side: I am uploading a " * .nidm.zip" file. This file generates a statistical map and a NIDM zip file (just this last one can be edited). Neurovault viewer complains about the "*.nidm.zip" of being a not recognized format, but if I try to open it, the NIDM viewer appears and I can edit the info (tags...) if I am the owner.  

:bulb: ?