### PR TITLE
Fix nidmviewer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN pip install uwsgi
 
 RUN pip install https://github.com/gallantlab/pycortex/archive/fe58400c8c3a3187d930b8a696cda8fec62c0f19.zip --egg
 RUN pip install git+https://github.com/benkonrath/django-guardian.git@7cded9081249e9a4cd9f5cd85e67cf843c138b0c#egg=django-guardian
-RUN pip install 'git+git://github.com/vsoch/nidmviewer.git@0.1'
+RUN pip install nidmviewer==0.1.3
 
 
 RUN apt-get install -y npm

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -368,7 +368,8 @@ def view_nidm_results(request, collection_cid, nidm_name):
 
     # We will remove these columns
     columns_to_remove = ["statmap_location","statmap",
-                         "statmap_type","coordinate_id"]
+                         "statmap_type","coordinate_id",
+                         "excsetmap_location"]
 
     # Text for the "Select image" button
     button_text = "Statistical Map"


### PR DESCRIPTION
This PR will do minor tweaks to close #521. Specifically, the nidmviewer version 0.1.3 has the check for empty images as a variable with default set to False, so maps are not checked for these voxels. Hopefully in the future the nidm results object can contain this information to make this check not necessary. Second, since we now are dealing with excursion sets, I added the `excsetmap_location` to the columns to remove variable.