### PR TITLE
Save Image Metadata via API

### DIFF
--- a/neurovault/api/serializers.py
+++ b/neurovault/api/serializers.py
@@ -121,24 +121,7 @@ class ImageSerializer(serializers.HyperlinkedModelSerializer,
         return cleaned_data
 
 
-class EditableImageSerializer(ImageSerializer,
-                              ImageValidationMixin):
-
-    def validate(self, data):
-        self.afni_subbricks = []
-        self.afni_tmp = None
-        self._errors = ErrorDict()
-        self.error_class = ErrorList
-
-        cleaned_data = self.clean_and_validate(data)
-
-        if self.errors:
-            raise serializers.ValidationError(self.errors)
-
-        return cleaned_data
-
-
-class EditableStatisticMapSerializer(EditableImageSerializer):
+class EditableStatisticMapSerializer(ImageSerializer):
     def __init__(self, *args, **kwargs):
         super(EditableStatisticMapSerializer, self).__init__(*args, **kwargs)
         self._metadata_dict = self.extract_metadata_fields(
@@ -235,7 +218,7 @@ class AtlasSerializer(ImageSerializer):
         return super(ImageSerializer, self).to_representation(obj)
 
 
-class EditableAtlasSerializer(EditableImageSerializer):
+class EditableAtlasSerializer(ImageSerializer):
 
     class Meta:
         model = Atlas

--- a/neurovault/api/serializers.py
+++ b/neurovault/api/serializers.py
@@ -79,7 +79,6 @@ class ImageSerializer(serializers.HyperlinkedModelSerializer,
 
     def __init__(self, *args, **kwargs):
         super(ImageSerializer, self).__init__(*args, **kwargs)
-        # import pudb; pudb.set_trace()
         initial_data = getattr(self, 'initial_data', None)
         if initial_data:
             self._metadata_dict = self.extract_metadata_fields(
@@ -137,7 +136,9 @@ class ImageSerializer(serializers.HyperlinkedModelSerializer,
     def save(self, *args, **kwargs):
         metadata_dict = getattr(self, '_metadata_dict', None)
         if metadata_dict:
-            kwargs['data'] = self._metadata_dict
+            data = self.instance.data.copy()
+            data.update(self._metadata_dict)
+            kwargs['data'] = data
 
         super(ImageSerializer, self).save(*args, **kwargs)
 

--- a/neurovault/api/views.py
+++ b/neurovault/api/views.py
@@ -355,4 +355,3 @@ class TagViewSet(viewsets.ModelViewSet):
         from django.db.models import Count
         data = Tag.objects.annotate(action_count=Count('action'))
         return APIHelper.wrap_for_datatables(data)
-

--- a/neurovault/apps/statmaps/tests/test_api.py
+++ b/neurovault/apps/statmaps/tests/test_api.py
@@ -650,13 +650,40 @@ class TestStatisticMapChange(BaseTestCases.TestCollectionItemChange):
             'name': "renamed %s" % uuid.uuid4(),
             'modality': 'fMRI-BOLD',
             'map_type': 'T',
-            'file': file
+            'file': file,
+            'custom_metadata_numeric_field': 42
         }
 
         response = self.client.put(self.item_url, put_dict)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(response.data['name'], put_dict['name'])
+        self.assertEqual(response.data['custom_metadata_numeric_field'], 42)
+
+    def test_statistic_map_metadata_partial_update(self):
+        self.client.force_authenticate(user=self.user)
+
+        self.item.data['custom_metadata_field_a'] = 'a text'
+        self.item.data['custom_metadata_field_b'] = 'b text'
+        self.item.save()
+
+        patch_dict = {
+            'name': "renamed %s" % uuid.uuid4(),
+            'custom_metadata_field_b': 'override b with %s' % uuid.uuid4(),
+            'custom_metadata_field_c': 42,
+        }
+
+        response = self.client.patch(self.item_url, patch_dict)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(response.data['name'], patch_dict['name'])
+
+        self.assertEqual(response.data['custom_metadata_field_a'], 'a text')
+        self.assertEqual(
+            response.data['custom_metadata_field_b'],
+            patch_dict['custom_metadata_field_b']
+        )
+        self.assertEqual(response.data['custom_metadata_field_c'], 42)
 
     def test_statistic_map_destroy(self):
         self._test_collection_item_destroy(StatisticMap)

--- a/neurovault/apps/statmaps/tests/test_api.py
+++ b/neurovault/apps/statmaps/tests/test_api.py
@@ -670,7 +670,7 @@ class TestStatisticMapChange(BaseTestCases.TestCollectionItemChange):
         patch_dict = {
             'name': "renamed %s" % uuid.uuid4(),
             'custom_metadata_field_b': 'override b with %s' % uuid.uuid4(),
-            'custom_metadata_field_c': 42,
+            'custom_metadata_field_c': 42
         }
 
         response = self.client.patch(self.item_url, patch_dict)
@@ -684,6 +684,15 @@ class TestStatisticMapChange(BaseTestCases.TestCollectionItemChange):
             patch_dict['custom_metadata_field_b']
         )
         self.assertEqual(response.data['custom_metadata_field_c'], 42)
+
+        statmap = StatisticMap.objects.get(pk=response.data['id'])
+        self.assertEqual(statmap.data['custom_metadata_field_a'], 'a text')
+        self.assertEqual(
+            statmap.data['custom_metadata_field_b'],
+            patch_dict['custom_metadata_field_b']
+        )
+        self.assertEqual(statmap.data['custom_metadata_field_c'], '42')
+        self.assertEqual(statmap.data['custom_metadata_field_d'], '42')
 
     def test_statistic_map_destroy(self):
         self._test_collection_item_destroy(StatisticMap)

--- a/neurovault/apps/statmaps/tests/test_api.py
+++ b/neurovault/apps/statmaps/tests/test_api.py
@@ -398,7 +398,7 @@ class TestCollectionItemUpload(APITestCase):
         response = self.client.post(url, post_dict, format='multipart')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        self.assertEqual(response.data['collection'], self.coll.id)
+        self.assertEqual(response.data['collection_id'], self.coll.id)
         self.assertRegexpMatches(response.data['file'], r'\.nii\.gz$')
 
         exclude_keys = ('file',)
@@ -424,11 +424,12 @@ class TestCollectionItemUpload(APITestCase):
         response = self.client.post(url, post_dict, format='multipart')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        self.assertEqual(response.data['collection'], self.coll.id)
+        self.assertEqual(response.data['collection_id'], self.coll.id)
         self.assertRegexpMatches(response.data['file'], r'\.nii\.gz$')
 
         exclude_keys = (
             'file',
+            'map_type',
             'custom_metadata_numeric_field',
             'custom_metadata_string_field'
         )
@@ -437,14 +438,17 @@ class TestCollectionItemUpload(APITestCase):
         for key in test_keys:
             self.assertEqual(response.data[key], post_dict[key])
 
-        statmap = StatisticMap.objects.get(pk=response.data['id'])
+        self.assertEqual(response.data['custom_metadata_numeric_field'], 42)
 
-        for key in ('custom_metadata_numeric_field',
-                    'custom_metadata_string_field'):
-            self.assertEqual(
-                statmap.data['custom_metadata_numeric_field'],
-                post_dict[key]
-            )
+        statmap = StatisticMap.objects.get(pk=response.data['id'])
+        self.assertEqual(
+            statmap.map_type, 'T'
+        )
+        self.assertEqual(statmap.data['custom_metadata_numeric_field'], '42')
+        self.assertEqual(
+            statmap.data['custom_metadata_string_field'],
+            'forty two'
+        )
 
     def test_upload_atlas(self):
         self.client.force_authenticate(user=self.user)
@@ -465,7 +469,7 @@ class TestCollectionItemUpload(APITestCase):
         response = self.client.post(url, post_dict, format='multipart')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        self.assertEqual(response.data['collection'], self.coll.id)
+        self.assertEqual(response.data['collection_id'], self.coll.id)
         self.assertRegexpMatches(response.data['file'], r'\.nii\.gz$')
         self.assertRegexpMatches(response.data['label_description_file'],
                                  r'\.xml$')

--- a/neurovault/apps/statmaps/tests/test_api.py
+++ b/neurovault/apps/statmaps/tests/test_api.py
@@ -401,8 +401,8 @@ class TestCollectionItemUpload(APITestCase):
         self.assertEqual(response.data['collection_id'], self.coll.id)
         self.assertRegexpMatches(response.data['file'], r'\.nii\.gz$')
 
-        exclude_keys = ('file',)
-        test_keys = set(post_dict.keys()) - set(exclude_keys)
+        exclude_keys = set(['file', 'map_type'])
+        test_keys = post_dict.viewkeys() - exclude_keys
         for key in test_keys:
             self.assertEqual(response.data[key], post_dict[key])
 
@@ -427,14 +427,14 @@ class TestCollectionItemUpload(APITestCase):
         self.assertEqual(response.data['collection_id'], self.coll.id)
         self.assertRegexpMatches(response.data['file'], r'\.nii\.gz$')
 
-        exclude_keys = (
+        exclude_keys = set([
             'file',
             'map_type',
             'custom_metadata_numeric_field',
             'custom_metadata_string_field'
-        )
+        ])
 
-        test_keys = set(post_dict.keys()) - set(exclude_keys)
+        test_keys = post_dict.viewkeys() - exclude_keys
         for key in test_keys:
             self.assertEqual(response.data[key], post_dict[key])
 

--- a/neurovault/apps/statmaps/tests/test_api.py
+++ b/neurovault/apps/statmaps/tests/test_api.py
@@ -692,7 +692,6 @@ class TestStatisticMapChange(BaseTestCases.TestCollectionItemChange):
             patch_dict['custom_metadata_field_b']
         )
         self.assertEqual(statmap.data['custom_metadata_field_c'], '42')
-        self.assertEqual(statmap.data['custom_metadata_field_d'], '42')
 
     def test_statistic_map_destroy(self):
         self._test_collection_item_destroy(StatisticMap)


### PR DESCRIPTION
This PR adds an ability to add and edit custom fields (aka "image metadata") in StatisticalMaps via the NeuroVault API.

