### PR TITLE
Fix cognitive atlas properties update

### DIFF
--- a/neurovault/api/serializers.py
+++ b/neurovault/api/serializers.py
@@ -7,13 +7,23 @@ from django.utils.http import urlquote
 from rest_framework import serializers
 from rest_framework.relations import PrimaryKeyRelatedField, StringRelatedField
 
-from neurovault.apps.statmaps.forms import (handle_update_ttl_urls,
-                                            ImageValidationMixin,
-                                            NIDMResultsValidationMixin,
-                                            save_nidm_statmaps)
-from neurovault.apps.statmaps.models import (Atlas, Collection, NIDMResults,
-                                             NIDMResultStatisticMap,
-                                             StatisticMap, BaseCollectionItem)
+from neurovault.apps.statmaps.forms import (
+    handle_update_ttl_urls,
+    ImageValidationMixin,
+    NIDMResultsValidationMixin,
+    save_nidm_statmaps
+)
+
+from neurovault.apps.statmaps.models import (
+    Atlas,
+    BaseCollectionItem,
+    CognitiveAtlasTask,
+    CognitiveAtlasContrast,
+    Collection,
+    NIDMResults,
+    NIDMResultStatisticMap,
+    StatisticMap
+)
 
 
 class HyperlinkedFileField(serializers.FileField):
@@ -57,6 +67,7 @@ class NIDMDescriptionSerializedField(serializers.CharField):
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
+
     class Meta:
         model = User
         fields = ('id', 'username', 'email', 'first_name', 'last_name')
@@ -144,6 +155,16 @@ class ImageSerializer(serializers.HyperlinkedModelSerializer,
 
 
 class EditableStatisticMapSerializer(ImageSerializer):
+    cognitive_paradigm_cogatlas = PrimaryKeyRelatedField(
+        queryset=CognitiveAtlasTask.objects.all(),
+        allow_null=True,
+        required=False
+    )
+    cognitive_contrast_cogatlas = PrimaryKeyRelatedField(
+        queryset=CognitiveAtlasContrast.objects.all(),
+        allow_null=True,
+        required=False
+    )
 
     class Meta:
         model = StatisticMap
@@ -203,7 +224,9 @@ class NIDMResultStatisticMapSerializer(ImageSerializer):
         return obj.get_analysis_level_display()
 
     def get_nidm_results_ttl(self, obj):
-        return self.context['request'].build_absolute_uri(obj.nidm_results.ttl_file.url)
+        return self.context['request'].build_absolute_uri(
+            obj.nidm_results.ttl_file.url
+        )
 
     class Meta:
         model = NIDMResultStatisticMap
@@ -261,6 +284,7 @@ class NIDMResultsSerializer(serializers.ModelSerializer,
 
 class EditableNIDMResultsSerializer(serializers.ModelSerializer,
                                     NIDMResultsValidationMixin):
+
     def validate(self, data):
         data['collection'] = self.instance.collection
         return self.clean_and_validate(data)

--- a/neurovault/api/tests/test_collection_item_upload.py
+++ b/neurovault/api/tests/test_collection_item_upload.py
@@ -33,7 +33,8 @@ class TestCollectionItemUpload(APITestCase):
             'name': 'test map',
             'modality': 'fMRI-BOLD',
             'map_type': 'T',
-            'cognitive_paradigm_cogatlas': 'trm_4f24126c22011',
+            'cognitive_paradigm_cogatlas': 'tsk_4a57abb949846',
+            'cognitive_contrast_cogatlas': 'cnt_4e08fefbf0382',
             'file': SimpleUploadedFile(fname, open(fname).read())
         }
 
@@ -43,10 +44,17 @@ class TestCollectionItemUpload(APITestCase):
         self.assertEqual(response.data['collection_id'], self.coll.id)
         self.assertRegexpMatches(response.data['file'], r'\.nii\.gz$')
 
-        exclude_keys = set(['file', 'map_type'])
-        test_keys = post_dict.viewkeys() - exclude_keys
-        for key in test_keys:
+        self.assertEqual(response.data['cognitive_paradigm_cogatlas'],
+                         'action observation task')
+
+        for key in ('name', 'modality'):
             self.assertEqual(response.data[key], post_dict[key])
+
+        statmap = StatisticMap.objects.get(pk=response.data['id'])
+        self.assertEqual(statmap.cognitive_paradigm_cogatlas.name,
+                         'action observation task')
+        self.assertEqual(statmap.cognitive_contrast_cogatlas.name,
+                         'standard deviation from the mean accuracy score')
 
     def test_upload_statmap_with_metadata(self):
         self.client.force_authenticate(user=self.user)

--- a/neurovault/api/tests/test_collection_item_upload.py
+++ b/neurovault/api/tests/test_collection_item_upload.py
@@ -33,6 +33,7 @@ class TestCollectionItemUpload(APITestCase):
             'name': 'test map',
             'modality': 'fMRI-BOLD',
             'map_type': 'T',
+            'cognitive_paradigm_cogatlas': 'trm_4f24126c22011',
             'file': SimpleUploadedFile(fname, open(fname).read())
         }
 

--- a/neurovault/api/tests/test_statistic_map.py
+++ b/neurovault/api/tests/test_statistic_map.py
@@ -28,6 +28,8 @@ class TestStatisticMapChange(BaseTestCases.TestCollectionItemChange):
             'modality': 'fMRI-BOLD',
             'map_type': 'T',
             'file': file,
+            'cognitive_paradigm_cogatlas': 'tsk_4a57abb949846',
+            'cognitive_contrast_cogatlas': 'cnt_4e08fefbf0382',
             'custom_metadata_numeric_field': 42
         }
 
@@ -36,6 +38,12 @@ class TestStatisticMapChange(BaseTestCases.TestCollectionItemChange):
 
         self.assertEqual(response.data['name'], put_dict['name'])
         self.assertEqual(response.data['custom_metadata_numeric_field'], 42)
+
+        statmap = StatisticMap.objects.get(pk=response.data['id'])
+        self.assertEqual(statmap.cognitive_paradigm_cogatlas.name,
+                         'action observation task')
+        self.assertEqual(statmap.cognitive_contrast_cogatlas.name,
+                         'standard deviation from the mean accuracy score')
 
     def test_statistic_map_metadata_partial_update(self):
         self.client.force_authenticate(user=self.user)

--- a/neurovault/api/views.py
+++ b/neurovault/api/views.py
@@ -12,7 +12,7 @@ from rest_framework.views import APIView
 from taggit.models import Tag
 
 from neurovault.apps.statmaps.models import (Atlas, Collection, Image,
-                                             NIDMResults)
+                                             StatisticMap, NIDMResults)
 from neurovault.apps.statmaps.views import (get_collection, get_image,
                                             owner_or_contrib)
 from neurovault.apps.statmaps.voxel_query_functions import (getAtlasVoxels,
@@ -108,6 +108,26 @@ class ImageViewSet(mixins.RetrieveModelMixin,
         image = self._get_api_image(request, pk)
         data = ImageSerializer(image, context={'request': request}).data
         return Response(data)
+
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop('partial', False)
+        instance = self.get_object()
+        if isinstance(instance, StatisticMap):
+            serializer = EditableStatisticMapSerializer(
+                data=request.data,
+                instance=instance,
+                context={'request': request},
+                partial=partial
+            )
+        else:
+            serializer = self.get_serializer(
+                instance,
+                data=request.data,
+                partial=partial
+            )
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        return Response(serializer.data)
 
 
 class AtlasViewSet(ImageViewSet):


### PR DESCRIPTION
This fixes the `"Invalid hyperlink - No URL match"` error when updating Cognitive Paradigm or Cognitive Atlas Contrast properties of statistical maps via API.