### PR TITLE
Downloaded files keep the full name for the zip file.

### DIFF
--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -1224,7 +1224,7 @@ def download_collection(request, cid):
         zf.write(fpath, zip_path)
 
     response = StreamingHttpResponse(zf, content_type='application/zip')
-    response['Content-Disposition'] = 'attachment; filename=%s' % zip_filename
+    response['Content-Disposition'] = 'attachment; filename=%s' % zip_filename.replace (" ", "_")
     return response
 
 def serve_surface_archive(request, pk, collection_cid=None):

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -11,6 +11,7 @@ import shutil
 import tarfile
 import tempfile
 import traceback
+import urllib
 import zipfile
 import zipstream
 from collections import OrderedDict
@@ -1224,7 +1225,7 @@ def download_collection(request, cid):
         zf.write(fpath, zip_path)
 
     response = StreamingHttpResponse(zf, content_type='application/zip')
-    response['Content-Disposition'] = 'attachment; filename=%s' % zip_filename.replace (" ", "_")
+    response['Content-Disposition'] = 'attachment; filename=%s' % urllib.quote_plus(zip_filename)
     return response
 
 def serve_surface_archive(request, pk, collection_cid=None):


### PR DESCRIPTION
For Collections with names `test_collection` the generated zipfile name is `test_collection.zip`. 
For Collections with names `test collection` the generated zipfile name is `test` due to the space between words. 

Small change to correct this issue, replacing spaces for underscores. 