### PR TITLE
Set a copy row limit to the length of the data in Handsontable (on the edit metadata page)

### DIFF
--- a/neurovault/apps/statmaps/static/scripts/metadata-edit.js
+++ b/neurovault/apps/statmaps/static/scripts/metadata-edit.js
@@ -255,6 +255,7 @@
         allowInsertRow: false,
         minSpareRows: 0,
         maxRows: window.NVMetadata.data.length,
+        copyRowsLimit: window.NVMetadata.data.length,
         contextMenu: {
           callback: function (key) {
             if (key === 'insert_column_left' ||


### PR DESCRIPTION
(overrides default value of 1000)