### PR TITLE
tweak gene expression to link to Neurosynth

### DIFF
--- a/neurovault/apps/statmaps/templates/statmaps/gene_expression.html.haml
+++ b/neurovault/apps/statmaps/templates/statmaps/gene_expression.html.haml
@@ -19,7 +19,7 @@
         			"columnDefs": [
 										{
 											"render": function ( data, type, row ) {
-												return "<a href='http://www.ncbi.nlm.nih.gov/gene/" + row[1] +"'>" + data + "</a>";
+												return data + " <a href='http://www.ncbi.nlm.nih.gov/gene/" + row[1] +"'>[NCBI]</a> <a href='http://neurosynth.org/genes/" + data +"'>[Neurosynth]</a>";
 											},
 											"targets":[ 0 ]
 										},


### PR DESCRIPTION
Here's a first pass at this. Works fine but may need some tweaking as it's kind of ugly. Feel free to modify, or suggest a better way to present the info. Maybe we should add extra table columns for NCBI and NS links? Or shorten Neurosynth to 'NS'?