### PR TITLE
Add a `private` property to the collections api response

### DIFF
--- a/neurovault/api/serializers.py
+++ b/neurovault/api/serializers.py
@@ -323,7 +323,6 @@ class CollectionSerializer(serializers.ModelSerializer):
     owner_name = serializers.SerializerMethodField()
     number_of_images = serializers.SerializerMethodField('num_im')
 
-
     def num_im(self, obj):
         return obj.basecollectionitem_set.count()
 

--- a/neurovault/api/serializers.py
+++ b/neurovault/api/serializers.py
@@ -354,6 +354,6 @@ class CollectionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Collection
-        exclude = ['private_token', 'private', 'images']
+        exclude = ['private_token', 'images']
         # Override `required` to allow name fetching by DOI
         extra_kwargs = {'name': {'required': False}}


### PR DESCRIPTION
This PR adds `private` property to collection objects in the API response. 

It went missing in 371fa8539a6aecbbe784da3f703f6af96487b775. Is the reason for excluding it still relevant?  Now as we have `my_collections` endpoint, `private` could be quite useful.

If it's OK to bring it back, I'll add some tests to the PR.