### PR TITLE
Fix import of NIDM-Results pack with F-tests

### DIFF
--- a/neurovault/apps/statmaps/nidm_results.py
+++ b/neurovault/apps/statmaps/nidm_results.py
@@ -63,18 +63,13 @@ class NIDMUpload:
         prefix prov: <http://www.w3.org/ns/prov#>
         prefix nidm: <http://purl.org/nidash/nidm#>
 
-        prefix contrast_estimation: <http://purl.org/nidash/nidm#NIDM_0000001>
-        prefix contrast_map: <http://purl.org/nidash/nidm#NIDM_0000002>
         prefix contrast_name: <http://purl.org/nidash/nidm#NIDM_0000085>
         prefix statistic_map: <http://purl.org/nidash/nidm#NIDM_0000076>
         prefix statistic_type: <http://purl.org/nidash/nidm#NIDM_0000123>
 
         SELECT ?rdfLabel ?contrastName ?statType ?statFile WHERE {
-         ?cid a contrast_map: ;
-              contrast_name: ?contrastName .
-         ?cea a contrast_estimation: .
-         ?cid prov:wasGeneratedBy ?cea .
          ?sid a statistic_map: ;
+              contrast_name: ?contrastName ;
               statistic_type: ?statType ;
               rdfs:label ?rdfLabel ;
               prov:atLocation ?statFile .


### PR DESCRIPTION
This PR fixes an issue identified by @AlexBowring.

**Description of the problem**: When uploading a NIDM-Results pack containing an F-test but no T-test (e.g. [this one](https://drive.google.com/file/d/0B5rWMFQteK5edHlaZUM1TTVIbzg/view?usp=sharing)), the upload fails and NeuroVault returns "Invalid NIDM-Results file".

**Fix**: When loading the statistic maps available in a NIDM-Results pack, NeuroVault is looking for contrast maps to retrieve the corresponding contrast name. But contrast maps are only defined for T-tests (cf. [Contrast estimation in NIDM-Results](http://nidm.nidash.org/specs/nidm-results_130.html#h-contrast-estimation)). This PR updates the query to get the contrast name directly from the statistic maps. This solves the issue (tested on 1 example only) and should insure that the correct contrast name is associated with each statistic map.

Please let us know what you think of this. Thanks!