### PR TITLE
Issue 299

### DIFF
--- a/neurovault/apps/statmaps/tests/test_comparison.py
+++ b/neurovault/apps/statmaps/tests/test_comparison.py
@@ -210,3 +210,34 @@ class ComparisonTestCase(TestCase):
         print "Success for this test means the pandas DataFrame shows the copy in first position with score of 1"
         self.assertEqual(similar_images['image_id'][0], int(image2.pk))
         self.assertEqual(similar_images['score'][0], 1)
+
+    def test_update_metrics(self):
+        collection1 = Collection(name='Collection1', owner=self.u1,
+                                 DOI='10.3389/fninf.2015.00099')
+
+        collection1.save()
+        collection2 = Collection(name='Collection2', owner=self.u1,
+                                 DOI='10.3389/fninf.2015.00089')
+        collection2.save()
+
+        app_path = os.path.abspath(os.path.dirname(__file__))
+        image1 = save_statmap_form(image_path=os.path.join(app_path, 'test_data/statmaps/all.nii.gz'),
+                                   collection=collection1,
+                                   image_name="image1")
+        image2 = save_statmap_form(image_path=os.path.join(app_path, 'test_data/statmaps/beta_0001.nii.gz'),
+                                   collection=collection2,
+                                   image_name="image2")
+
+        similar_images = get_similar_images(int(image1.pk))
+        similarity_score_1 = similar_images['score'][0]
+
+        image2 = save_statmap_form(image_path=os.path.join(app_path, 'test_data/statmaps/saccade.I_C.MNI.nii.gz'),
+                                   collection=collection2,
+                                   image_name="image2")
+
+        similar_images = get_similar_images(int(image1.pk))
+        similarity_score_2 = similar_images['score'][0]
+
+        print similarity_score_1, similarity_score_2
+        print "Success for this test means that similarity scores changed"
+        self.assertNotEqual(similarity_score_1, similarity_score_2)

--- a/neurovault/apps/statmaps/tests/test_comparison.py
+++ b/neurovault/apps/statmaps/tests/test_comparison.py
@@ -212,6 +212,8 @@ class ComparisonTestCase(TestCase):
         self.assertEqual(similar_images['score'][0], 1)
 
     def test_update_metrics(self):
+        from django.core.files import File
+
         collection1 = Collection(name='Collection1', owner=self.u1,
                                  DOI='10.3389/fninf.2015.00099')
 
@@ -228,16 +230,20 @@ class ComparisonTestCase(TestCase):
                                    collection=collection2,
                                    image_name="image2")
 
-        similar_images = get_similar_images(int(image1.pk))
+        similar_images = get_similar_images(int(image2.pk))
         similarity_score_1 = similar_images['score'][0]
 
-        image2 = save_statmap_form(image_path=os.path.join(app_path, 'test_data/statmaps/saccade.I_C.MNI.nii.gz'),
-                                   collection=collection2,
-                                   image_name="image2")
+        image_path = os.path.join(app_path, 'test_data/statmaps/all.nii.gz')
+        f = open(image_path)
+        niftiFile = File(f)
+        my_file_name = 'another_name_but_same_image.nii.gz'
+        image2.file.save(my_file_name, niftiFile)
+        image2.save()
 
-        similar_images = get_similar_images(int(image1.pk))
+        similar_images = get_similar_images(int(image2.pk))
         similarity_score_2 = similar_images['score'][0]
 
-        print similarity_score_1, similarity_score_2
         print "Success for this test means that similarity scores changed"
         self.assertNotEqual(similarity_score_1, similarity_score_2)
+        print "Success for this test means that similarity score is 1"
+        self.assertEqual(similarity_score_2, 1)


### PR DESCRIPTION
Test for #299 . The test works fine without changing anything in the code. I've been trying to reproduce the bug vainly. 

I though that `run_voxelwise_pearson_similarity.apply_async([image.pk])` had to be added to [this](https://github.com/NeuroVault/NeuroVault/blob/master/neurovault/apps/statmaps/models.py#L393-L395) clause, but seems like it is not needed. 
:thinking: 

BTW: I'm getting an error in the tests.
`test_adding_nidm:
ValueError: The NIDMResults could not be created because the data didn't validate.
`
