### PR TITLE
fix: Remove readonly if deletion of NIDM pack fails

### DIFF
--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -25,6 +25,8 @@ from neurovault.apps.statmaps.storage import DoubleExtensionStorage, NIDMStorage
 from neurovault.apps.statmaps.tasks import run_voxelwise_pearson_similarity, generate_glassbrain_image
 from neurovault.settings import PRIVATE_MEDIA_ROOT
 
+import stat
+
 
 class Collection(models.Model):
     name = models.CharField(max_length=200, unique = True, null=False, verbose_name="Name of collection")
@@ -601,7 +603,14 @@ class NIDMResults(BaseCollectionItem):
 def mymodel_delete(sender, instance, **kwargs):
     nidm_path = os.path.dirname(instance.zip_file.path)
     if os.path.isdir(nidm_path):
-        shutil.rmtree(nidm_path)
+        shutil.rmtree(nidm_path, onerror=remove_readonly)
+
+# Solution to deleting read-only files from: 
+# https://docs.python.org/3/library/shutil.html#rmtree-example
+def remove_readonly(func, path, _):
+    "Clear the readonly bit and reattempt the removal"
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
 
 post_save.connect(basecollectionitem_created, sender=NIDMResults, weak=True)
 

--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -605,7 +605,7 @@ def mymodel_delete(sender, instance, **kwargs):
     if os.path.isdir(nidm_path):
         shutil.rmtree(nidm_path, onerror=remove_readonly)
 
-# Solution to deleting read-only files from: 
+# Solution to delete read-only files from: 
 # https://docs.python.org/3/library/shutil.html#rmtree-example
 def remove_readonly(func, path, _):
     "Clear the readonly bit and reattempt the removal"


### PR DESCRIPTION
This PR should fix #597 (cf. discussions in that issue).