### PR TITLE
Change 'http' into 'https' in domain name

### DIFF
--- a/neurovault/settings.py
+++ b/neurovault/settings.py
@@ -13,7 +13,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 DEBUG = True
 
-DOMAIN_NAME = "http://neurovault.org"
+DOMAIN_NAME = "https://neurovault.org"
 
 TEMPLATE_DEBUG = DEBUG
 


### PR DESCRIPTION
This is a very simple update which changes 'http' into 'https' into the `DOMAIN_NAME` variable. 

This will ensure that any NIDM pack uploaded will include https paths to the images (rather than http  then redirected to https).

*But* I don't know how this will impact the rest of NeuroVault so please feel free to ignore if you think that's a bad idea. (The updated nidmviewer should work regardless.)

