### PR TITLE
Correct FAQ formatting

### DIFF
--- a/neurovault/apps/main/templates/FAQ.html.haml
+++ b/neurovault/apps/main/templates/FAQ.html.haml
@@ -49,5 +49,6 @@
         .well     
             %p All data in NeuroVault (with exclusion of private collections) is distributed under <a href="http://creativecommons.org/publicdomain/zero/1.0/">CC0 license</a>.
         %h4 14. My image looks perfectly aligned with the MNI template in FSLView but when I upload it to NeuroVault it's misaligned in the web viewver.
+        .well
             %p Use this command line FSL tool: fslcpgeom MNIatlas image_with_weird_header. (Many thanks to Leonie Lampe for the tip).
 {% endblock %}


### PR DESCRIPTION
The last FAQ was added in #576, but it looks like the answer didn't make it into a `.well` class. This PR fixes that. 

It'd probably also be nice to make the suggested code stand out from the rest of the text, à la
>Use this command line FSL tool: `fslcpgeom MNIatlas image_with_weird_header`. (Many thanks to Leonie Lampe for the tip).

but I don't know enough about HAML to accomplish this (maybe `` `code` `` would be enough, but I couldn't quickly figure out how markdown-enabled HAML was out of the box)