### PR TITLE
Adding communities

### DIFF
--- a/neurovault/apps/main/templates/base.html
+++ b/neurovault/apps/main/templates/base.html
@@ -57,7 +57,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="{% url 'index' %}">NeuroVault</a>
+            <a class="navbar-brand" href="{% url 'index' %}">NeuroVault</a><a class="navbar-brand" style="margin-left: -22px" href="{{ name_subscript_url }}"><sub>{{ name_subscript }}</sub></a>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->

--- a/neurovault/apps/main/templates/index.html.haml
+++ b/neurovault/apps/main/templates/index.html.haml
@@ -14,11 +14,11 @@ var addthis_config = {
     .span11
         .massive
             .p <img src='{% static "images/neurovault-logo.png"%}' alt="triangle with equal sides" srcset='{% static "images/neurovault-logo.svg"%}'>
-            .lead A public repository of unthresholded statistical maps, <br />parcellations, and atlases of the brain
+            .lead {{ tagline | safe }}
 .row
     .third.slice
         .light-head.center-text What is it?
-        %p A place where researchers can publicly store and share unthresholded statistical maps, parcellations, and atlases produced by MRI and PET studies.
+        %p {{ what_is_it | safe }}
     .third.slice
         .light-head.center-text Why use it?
         %ul.benefit-list
@@ -45,7 +45,7 @@ var addthis_config = {
         %hr
 .row
     .span11{:style => "padding: 0 0 0 0px;"}
-        %h4 Recently added collections of images from published papers
+        %h4 {{ query_explanation }}
         %table.table.table-striped
             %thead
                 %tr

--- a/neurovault/apps/main/urls.py
+++ b/neurovault/apps/main/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 from django.contrib import admin
-from .views import index_view
+from .views import index_view, community_view
 from django.views.generic.base import TemplateView
 admin.autodiscover()
 
@@ -11,4 +11,8 @@ urlpatterns = patterns('',
         name="FAQ"),
     url(r'^api-docs', TemplateView.as_view(template_name="api-docs.html"), 
         name="api-docs"),
+
+   url(r'^communities/(?P<community_label>[a-z]+)/$',
+       community_view,
+       name='view_community')
 )

--- a/neurovault/apps/main/views.py
+++ b/neurovault/apps/main/views.py
@@ -1,6 +1,8 @@
+from django.core.urlresolvers import reverse
 from django.db.models.aggregates import Count
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 
+from neurovault.apps.statmaps.models import Community
 from ..statmaps.models import Collection
 
 
@@ -9,5 +11,29 @@ def index_view(request):
     #this is faster than using annotate and count!
     recent_collections = [col for col in recent_collections if col.basecollectionitem_set.count() > 0][:10]
     
-    context = {'recent_collections': recent_collections}
+    context = {'recent_collections': recent_collections,
+               'query_explanation': "Recently added collections of images from published papers",
+               'tagline': "A public repository of unthresholded statistical maps, <br />"
+                          "parcellations, and atlases of the brain",
+               'what_is_it': "A place where researchers can publicly store and share unthresholded statistical maps, parcellations, and atlases produced by MRI and PET studies."}
+
     return render(request, 'index.html.haml', context)
+
+
+def community_view(request, community_label):
+    community = get_object_or_404(Community, label=community_label)
+
+    recent_collections = community.collections.exclude(private=True).order_by('-doi_add_date')
+    # this is faster than using annotate and count!
+    recent_collections = [col for col in recent_collections if col.basecollectionitem_set.count() > 0][:10]
+
+    context = {'recent_collections': recent_collections,
+               'query_explanation': "Recently added collections of images from the %s Community"%community.short_desc,
+               'tagline': "A public repository of unthresholded statistical maps, <br />"
+                          "parcellations, and atlases of the brain <br />"
+                          "from the %s Community"%community.short_desc,
+               'what_is_it': "A place where %s researchers can publicly store and share unthresholded statistical maps, parcellations, and atlases produced by MRI and PET studies."%community.short_desc,
+               'name_subscript': community.label,
+               'name_subscript_url': reverse('view_community', kwargs={'community_label': community_label})}
+    return render(request, 'index.html.haml', context)
+

--- a/neurovault/apps/statmaps/forms.py
+++ b/neurovault/apps/statmaps/forms.py
@@ -47,6 +47,7 @@ from guardian.shortcuts import get_objects_for_user
 collection_fieldsets = [
     ('Essentials', {'fields': ['name',
                                'DOI',
+                               'community',
                                'description',
                                'full_dataset_url',
                                'contributors',

--- a/neurovault/apps/statmaps/forms.py
+++ b/neurovault/apps/statmaps/forms.py
@@ -47,7 +47,7 @@ from guardian.shortcuts import get_objects_for_user
 collection_fieldsets = [
     ('Essentials', {'fields': ['name',
                                'DOI',
-                               'community',
+                               'communities',
                                'description',
                                'full_dataset_url',
                                'contributors',

--- a/neurovault/apps/statmaps/migrations/0076_auto_20180702_0152.py
+++ b/neurovault/apps/statmaps/migrations/0076_auto_20180702_0152.py
@@ -3,6 +3,14 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
+def add_nutrition_and_developmental(apps, schema_editor):
+    # We can't import the Person model directly as it may be a newer
+    # version than this migration expects. We use the historical version.
+    Community = apps.get_model("statmaps", "Community")
+
+    Community.create(label="developmental", short_desc="Developmental Neuroscience")
+    Community.create(label="nutritional", short_desc="Nutritional Neuroscience")
+
 
 class Migration(migrations.Migration):
 
@@ -22,6 +30,8 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='collection',
             name='communities',
-            field=models.ManyToManyField(related_query_name=b'community', related_name='collection_communities', default=None, to='statmaps.Community', blank=True, help_text=b'Is this collection part of any special Communities?', verbose_name=b'Communities'),
+            field=models.ManyToManyField(related_query_name=b'community', related_name='collection_communities', default=None, to='statmaps.Community', blank=True, help_text=b'Is this collection part of any special Community?', verbose_name=b'Communities'),
         ),
+        migrations.RunPython(add_nutrition_and_developmental),
+
     ]

--- a/neurovault/apps/statmaps/migrations/0076_auto_20180702_0152.py
+++ b/neurovault/apps/statmaps/migrations/0076_auto_20180702_0152.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='collection',
             name='communities',
-            field=models.ManyToManyField(related_query_name=b'community', related_name='collection_communities', default=None, to='statmaps.Community', blank=True, help_text=b'Is this collection part of any special Community?', verbose_name=b'Communities'),
+            field=models.ManyToManyField(related_query_name=b'collection', related_name='collections', default=None, to='statmaps.Community', blank=True, help_text=b'Is this collection part of any special Community?', verbose_name=b'Communities'),
         ),
         migrations.RunPython(add_nutrition_and_developmental),
 

--- a/neurovault/apps/statmaps/migrations/0076_auto_20180702_0152.py
+++ b/neurovault/apps/statmaps/migrations/0076_auto_20180702_0152.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('statmaps', '0075_auto_20180416_0413'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Community',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('label', models.CharField(unique=True, max_length=200, verbose_name=b'Lexical label of the community')),
+                ('short_desc', models.CharField(max_length=200, verbose_name=b'Short description of the community')),
+            ],
+        ),
+        migrations.AddField(
+            model_name='collection',
+            name='communities',
+            field=models.ManyToManyField(related_query_name=b'community', related_name='collection_communities', default=None, to='statmaps.Community', blank=True, help_text=b'Is this collection part of any special Communities?', verbose_name=b'Communities'),
+        ),
+    ]

--- a/neurovault/apps/statmaps/migrations/0076_auto_20180702_0152.py
+++ b/neurovault/apps/statmaps/migrations/0076_auto_20180702_0152.py
@@ -8,8 +8,8 @@ def add_nutrition_and_developmental(apps, schema_editor):
     # version than this migration expects. We use the historical version.
     Community = apps.get_model("statmaps", "Community")
 
-    Community.create(label="developmental", short_desc="Developmental Neuroscience")
-    Community.create(label="nutritional", short_desc="Nutritional Neuroscience")
+    Community.objects.create(label="developmental", short_desc="Developmental Neuroscience")
+    Community.objects.create(label="nutritional", short_desc="Nutritional Neuroscience")
 
 
 class Migration(migrations.Migration):

--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -40,6 +40,16 @@ def get_possible_templates():
 def get_target_template_list():
     return [ (template, POSSIBLE_TEMPLATES[template]['name']) for template in POSSIBLE_TEMPLATES ]
 
+COMMUNITIES = {'developmental': {'short_desc': 'Developmental Neuroscience'},
+               'nutrition': {'short_desc': 'Nutrition Neuroscience'}}
+community_choices = []
+for k in COMMUNITIES.keys():
+    community_choices.append((k, COMMUNITIES[k]['short_desc']))
+
+class Community(models.Model):
+    label = models.CharField(max_length=200, unique=True, null=False, verbose_name="Lexical label of the community")
+    short_desc = models.CharField(max_length=200, null=False, verbose_name="Short description of the community")
+
 class Collection(models.Model):
     name = models.CharField(max_length=200, unique = True, null=False, verbose_name="Name of collection")
     DOI = models.CharField(max_length=200, unique=True, blank=True, null=True, default=None, verbose_name="DOI of the corresponding paper (required if you want your maps to be archived in Stanford Digital Repository)")
@@ -56,6 +66,11 @@ class Collection(models.Model):
     add_date = models.DateTimeField('date published', auto_now_add=True)
     modify_date = models.DateTimeField('date modified', auto_now=True)
     doi_add_date = models.DateTimeField('date the DOI was added', editable=False, blank=True, null=True, db_index=True)
+    communities = models.ManyToManyField(Community, related_name="collection_communities",
+                                         related_query_name="community", blank=True,
+                                         help_text="Is this collection part of any special Communities?",
+                                         verbose_name="Communities", default=None)
+
     type_of_design = models.CharField(choices=[('blocked', 'blocked'), ('eventrelated', 'event_related'), ('hybridblockevent', 'hybrid block/event'), ('other', 'other')], max_length=200, blank=True, help_text="Blocked, event-related, hybrid, or other", null=True, verbose_name="Type of design")
     number_of_imaging_runs = models.IntegerField(help_text="Number of imaging runs acquired", null=True, verbose_name="No. of imaging runs", blank=True)
     number_of_experimental_units = models.IntegerField(help_text="Number of blocks, trials or experimental units per imaging run", null=True, verbose_name="No. of experimental units", blank=True)

--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -69,8 +69,8 @@ class Collection(models.Model):
     add_date = models.DateTimeField('date published', auto_now_add=True)
     modify_date = models.DateTimeField('date modified', auto_now=True)
     doi_add_date = models.DateTimeField('date the DOI was added', editable=False, blank=True, null=True, db_index=True)
-    communities = models.ManyToManyField(Community, related_name="collection_communities",
-                                         related_query_name="community", blank=True,
+    communities = models.ManyToManyField(Community, related_name="collections",
+                                         related_query_name="collection", blank=True,
                                          help_text="Is this collection part of any special Community?",
                                          verbose_name="Communities", default=None)
 

--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -68,7 +68,7 @@ class Collection(models.Model):
     doi_add_date = models.DateTimeField('date the DOI was added', editable=False, blank=True, null=True, db_index=True)
     communities = models.ManyToManyField(Community, related_name="collection_communities",
                                          related_query_name="community", blank=True,
-                                         help_text="Is this collection part of any special Communities?",
+                                         help_text="Is this collection part of any special Community?",
                                          verbose_name="Communities", default=None)
 
     type_of_design = models.CharField(choices=[('blocked', 'blocked'), ('eventrelated', 'event_related'), ('hybridblockevent', 'hybrid block/event'), ('other', 'other')], max_length=200, blank=True, help_text="Blocked, event-related, hybrid, or other", null=True, verbose_name="Type of design")

--- a/neurovault/apps/statmaps/models.py
+++ b/neurovault/apps/statmaps/models.py
@@ -50,6 +50,9 @@ class Community(models.Model):
     label = models.CharField(max_length=200, unique=True, null=False, verbose_name="Lexical label of the community")
     short_desc = models.CharField(max_length=200, null=False, verbose_name="Short description of the community")
 
+    def __unicode__(self):
+        return self.short_desc
+
 class Collection(models.Model):
     name = models.CharField(max_length=200, unique = True, null=False, verbose_name="Name of collection")
     DOI = models.CharField(max_length=200, unique=True, blank=True, null=True, default=None, verbose_name="DOI of the corresponding paper (required if you want your maps to be archived in Stanford Digital Repository)")


### PR DESCRIPTION
Closes #626 

When adding/editing a collection one can pick a community
![screenshot_7](https://user-images.githubusercontent.com/238759/42142519-ba3fb642-7d64-11e8-9482-f5594f3fcbf1.png)

A new set of URLs is also available (/communities/<community_label> which upon deployment will be turned into <community_label>.neurovault.org for example nutritional.neurovault.org). Those URLs point to landing pages tailored to a specific community and displaying only collections of maps from that community:

![screenshot_8](https://user-images.githubusercontent.com/238759/42142565-f2241ef4-7d64-11e8-9831-6720fefc558e.png)
