### PR TITLE
Upgrade pip before installing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && apt-get install -y \
     libhdf5-8 \
     libgeos-dev
 
+RUN pip install --upgrade pip
+
 RUN pip install numpy
 RUN pip install cython scipy
 RUN pip install scikit-learn pandas h5py matplotlib

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN pip install uwsgi
 RUN pip install zipstream
 
 RUN pip install html5lib
-RUN pip install https://github.com/gallantlab/pycortex/archive/fe58400c8c3a3187d930b8a696cda8fec62c0f19.zip --egg
+RUN pip install https://github.com/gallantlab/pycortex/archive/fe58400c8c3a3187d930b8a696cda8fec62c0f19.zip
 RUN pip install git+https://github.com/benkonrath/django-guardian.git@7cded9081249e9a4cd9f5cd85e67cf843c138b0c#egg=django-guardian
 RUN pip install nidmviewer==0.1.3
 


### PR DESCRIPTION
This removes repeated stderr message during container build:

    You are using pip version 8.1.2, however version 10.0.1 is available.
    You should consider upgrading via the 'pip install --upgrade pip' command.