### PR TITLE
typos and broken links in the API documentation

### DIFF
--- a/neurovault/apps/main/templates/api-docs.html
+++ b/neurovault/apps/main/templates/api-docs.html
@@ -78,7 +78,7 @@
                 particular
                 collection specified by the pk value.</p>
             <p class="indented"> example: <a
-                    href='http://neurovault.org/api/collections/287'><code>neurovault.org/api/collections/20</code></a>
+                    href='http://neurovault.org/api/collections/287'><code>neurovault.org/api/collections/287</code></a>
             </p>
             <h5><code>/api/collections/{pk}/images</code></h5>
             <p class="indented"> Returns a json file containing a
@@ -86,7 +86,7 @@
                 by
                 the pk value.</p>
             <p class="indented"> example: <a
-                    href='http://neurovault.org/api/collections/287/images'><code>neurovault.org/api/collections/20/images</code></a>
+                    href='http://neurovault.org/api/collections/287/images'><code>neurovault.org/api/collections/287/images</code></a>
             </p>
             <h4> Images </h4>
 

--- a/neurovault/apps/main/templates/api-docs.html
+++ b/neurovault/apps/main/templates/api-docs.html
@@ -105,7 +105,7 @@
                 particular
                 atlas specified by the pk value.</p>
             <p class="indented"> example: <a
-                    href='http://neurovault.org/api/images/1266'><code>neurovault.org/api/images/1203</code></a>
+                    href='http://neurovault.org/api/images/1557'><code>neurovault.org/api/images/1557</code></a>
             </p>
 
             <h4> NIDM Results</h4>


### PR DESCRIPTION
I found 2 small problems with links on the [API documentation page](https://www.neurovault.org/api-docs):
1. in the example for `/api/images/{pk}/`, the pk value in the visible text and the value in the link don't match, and neither work. 
2. in the examples for `/api/collections/{pk}/` and `/api/collections/{pk}/images`, the pk value in the visible text is 20, but the value in the link is 287. 
