### PR TITLE
fix double .nii

### DIFF
--- a/neurovault/apps/statmaps/tests/test_compressed.py
+++ b/neurovault/apps/statmaps/tests/test_compressed.py
@@ -1,3 +1,4 @@
+import gzip
 import os
 import shutil
 import tarfile
@@ -72,3 +73,38 @@ class UploadFolderTestCase(TestCase):
         # Assert that self.post is actually returned by the post_detail view
         self.assertEqual(response.status_code, 302)
         self.assertEqual(self.coll.basecollectionitem_set.instance_of(Image).count(), 4)
+
+    def test_upload_handles_plain_and_gz_extensions(self):
+        test_path = os.path.abspath(os.path.dirname(__file__))
+        gz_source = os.path.join(test_path, "test_data/statmaps/motor_lips.nii.gz")
+        plain_target = os.path.join(self.tmpdir, "motor_lips_plain.nii")
+
+        with gzip.open(gz_source, "rb") as src, open(plain_target, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+
+        mixed_zip = os.path.join(self.tmpdir, "mixed_extensions.zip")
+        with ZipFile(mixed_zip, "w") as archive:
+            archive.write(gz_source, arcname="motor_lips.nii.gz")
+            archive.write(plain_target, arcname="motor_lips_plain.nii")
+
+        with open(mixed_zip, "rb") as fp:
+            response = self.client.post(
+                reverse(
+                    "statmaps:upload_folder", kwargs={"collection_cid": self.coll.id}
+                ),
+                {"collection_cid": self.coll.id, "file": fp},
+            )
+
+        self.assertEqual(response.status_code, 302)
+
+        images = list(self.coll.basecollectionitem_set.instance_of(Image))
+        self.assertEqual(len(images), 2)
+
+        for image in images:
+            self.assertTrue(image.file.name.endswith(".nii.gz"))
+            self.assertNotIn(".nii.nii.gz", image.file.name)
+
+        self.assertTrue(
+            any("motor_lips_plain" in image.file.name for image in images),
+            "Expected a converted .nii upload to be saved with a single .nii.gz extension",
+        )

--- a/neurovault/apps/statmaps/utils.py
+++ b/neurovault/apps/statmaps/utils.py
@@ -881,7 +881,7 @@ def create_image_from_nifti(
     map_type = detect_stat_map_type(file_path)
 
     # 3) Convert to .nii.gz (or squeeze dimensions)
-    name_without_ext = os.path.splitext(os.path.basename(file_path))[0]
+    _, name_without_ext, _ = split_filename(file_path)
     new_img = squeeze_and_save_as_nii_gz(nii, name_without_ext)
     
     # 4) Create model instance

--- a/neurovault/apps/statmaps/views.py
+++ b/neurovault/apps/statmaps/views.py
@@ -968,8 +968,7 @@ def upload_folder(request, collection_cid):
                         for label, fpath in nifti_files:
                             # If file is in an atlas map, pass the xml path
                             # (note: we need to handle possible path differences)
-                            path, name_ext = os.path.split(fpath)
-                            name_no_ext, _ = os.path.splitext(name_ext)
+                            path, name_no_ext, _ = split_filename(fpath)
                             atlas_xml = None
 
                             # For matching, you might need to store the 


### PR DESCRIPTION
some files are being uploaded with double .nii.nii.gz extensions, this should fix that issue.

example of problematic upload: https://neurovault.org/images/904290/